### PR TITLE
Fix controllers extending controller in unknown namespace.

### DIFF
--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -1,0 +1,10 @@
+<?php namespace Unisharp\Laravelfilemanager\controllers;
+
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+
+abstract class Controller extends BaseController
+{
+    use DispatchesJobs, ValidatesRequests;
+}

--- a/src/controllers/CropController.php
+++ b/src/controllers/CropController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\View;

--- a/src/controllers/DeleteController.php
+++ b/src/controllers/DeleteController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;
@@ -49,5 +49,5 @@ class DeleteController extends LfmController {
 
         return 'OK';
     }
-    
+
 }

--- a/src/controllers/DownloadController.php
+++ b/src/controllers/DownloadController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Response;

--- a/src/controllers/FolderController.php
+++ b/src/controllers/FolderController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;

--- a/src/controllers/ItemsController.php
+++ b/src/controllers/ItemsController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;
@@ -36,7 +36,7 @@ class ItemsController extends LfmController {
         return View::make($view)
             ->with(compact('files', 'file_info', 'directories', 'thumb_url'));
     }
-    
+
 
     private function getFileInfos($files, $type = 'Images')
     {
@@ -46,7 +46,7 @@ class ItemsController extends LfmController {
             $file_name = parent::getFileName($file);
             $file_created = filemtime($file);
             $file_size = number_format((File::size($file) / 1024), 2, ".", "");
-            
+
             if ($file_size > 1024) {
                 $file_size = number_format(($file_size / 1024), 2, ".", "") . " Mb";
             } else {

--- a/src/controllers/LfmController.php
+++ b/src/controllers/LfmController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;
@@ -19,7 +19,7 @@ class LfmController extends Controller {
      */
     public $file_location;
     public $dir_location;
-    
+
 
     /**
      * Constructor
@@ -27,9 +27,9 @@ class LfmController extends Controller {
     public function __construct()
     {
         $this->setPathAndType();
-        
+
         $this->checkMyFolderExists();
-        
+
         $this->checkSharedFolderExists();
     }
 
@@ -60,7 +60,7 @@ class LfmController extends Controller {
     private function setPathAndType()
     {
         // dd('type:'.Input::get('type'));
-        
+
         if (Input::has('type') && Input::get('type') === 'Files') {
             Session::put('lfm_type', 'Files');
             Session::put('lfm.file_location', Config::get('lfm.files_dir'));

--- a/src/controllers/RenameController.php
+++ b/src/controllers/RenameController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;
@@ -42,7 +42,7 @@ class RenameController extends LfmController {
             File::move($old_file, $new_file);
             return 'OK';
         }
-        
+
         File::move($old_file, $new_file);
 
         if (Session::get('lfm_type') == 'Images') {

--- a/src/controllers/ResizeController.php
+++ b/src/controllers/ResizeController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\View;

--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -1,6 +1,6 @@
 <?php namespace Unisharp\Laravelfilemanager\controllers;
 
-use App\Http\Controllers\Controller;
+use Unisharp\Laravelfilemanager\controllers\Controller;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Input;


### PR DESCRIPTION
All the controllers reference the parent controller with `use App\Http\Controllers\Controller;`. This doesn't work when you have a custom namespace, as the controller file no longer resolves through the `App` namespace.

```
PHP Fatal error:  Class 'App\Http\Controllers\Controller' not found in dir/vendor/Unisharp/laravel-filemanager/src/controllers/LfmController.php on line 15
```

To remedy this, I created a new abstract controller so that all the controllers can extend it instead of extending the one in an unknown namespace.

See https://github.com/tsawler/laravel-filemanager/pull/48