### PR TITLE
Fix - CKEditor getting incorrect url to file, after upload

### DIFF
--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -133,7 +133,7 @@ class UploadController extends LfmController {
 
     private function useFile($new_filename)
     {
-        $file = parent::getUrl() . $new_filename;
+        $file = parent::getUrl('directory') . $new_filename;
 
         return "<script type='text/javascript'>
 


### PR DESCRIPTION
CKEditor gets incorrect url to file something like, `/files/1filename.ext` instead of `/files/1/filename.ext` missing slash before filename.