### PR TITLE
Added forgotten last slash in result of getUrl function

### DIFF
--- a/src/controllers/LfmController.php
+++ b/src/controllers/LfmController.php
@@ -142,7 +142,7 @@ class LfmController extends Controller {
 
         $url = str_replace('\\','/',$url);
 
-        return $url;
+        return $url . '/';
     }
 
 


### PR DESCRIPTION
Hello!

When i try upload image from ckeditor's "image properties" window, in "upload" tab, "/laravel-filemanager/upload" route response JavaScript code has wrong image url.
For example: he returns a '/photos/1577488c96564f.png' string, while real url is '/photos/1/577488c96564f.png'

before:
![screenshot from 2016-06-30 09-57-08](https://cloud.githubusercontent.com/assets/615837/16475511/aad79556-3eb1-11e6-9dc9-ab35c1c361aa.png)
after:
![screenshot from 2016-06-30 09-58-07](https://cloud.githubusercontent.com/assets/615837/16475510/aa9638ae-3eb1-11e6-9b37-b7b0978cb718.png)