### PR TITLE
Added error handler to file upload and Corrected double file extensions in config

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -52,10 +52,10 @@ return [
     // file extensions array, only for showing file information, it won't affect the upload process.
     'file_type_array'         => [
         'pdf'  => 'Adobe Acrobat',
-        'docx' => 'Microsoft Word',
+        'doc'  => 'Microsoft Word',
         'docx' => 'Microsoft Word',
         'xls'  => 'Microsoft Excel',
-        'xls'  => 'Microsoft Excel',
+        'xlsx' => 'Microsoft Excel',
         'zip'  => 'Archive',
         'gif'  => 'GIF Image',
         'jpg'  => 'JPEG Image',
@@ -68,10 +68,10 @@ return [
     // file extensions array, only for showing icons, it won't affect the upload process.
     'file_icon_array'         => [
         'pdf'  => 'fa-file-pdf-o',
-        'docx' => 'fa-file-word-o',
+        'doc'  => 'fa-file-word-o',
         'docx' => 'fa-file-word-o',
         'xls'  => 'fa-file-excel-o',
-        'xls'  => 'fa-file-excel-o',
+        'xlsx' => 'fa-file-excel-o',
         'zip'  => 'fa-file-archive-o',
         'gif'  => 'fa-file-image-o',
         'jpg'  => 'fa-file-image-o',

--- a/src/lang/en/lfm.php
+++ b/src/lang/en/lfm.php
@@ -44,6 +44,8 @@ return [
     'error-mime'        => 'Unexpected MimeType: ',
     'error-instance'    => 'The uploaded file should be an instance of UploadedFile',
     'error-invalid'     => 'Invalid upload request',
+    'error-other'       => 'An error has occured: ',
+    'error-too-large'   => 'Request entity too large!',
 
     'btn-upload'        => 'Upload File',
     'btn-uploading'     => 'Uploading...',

--- a/src/views/script.blade.php
+++ b/src/views/script.blade.php
@@ -37,7 +37,8 @@ $('#add-folder').click(function () {
 $('#upload-btn').click(function () {
   var options = {
     beforeSubmit:  showRequest,
-    success:       showResponse
+    success:       showResponse,
+    error:         showError
   };
 
   function showRequest(formData, jqForm, options) {
@@ -53,6 +54,17 @@ $('#upload-btn').click(function () {
     }
     $('#upload').val('');
     loadItems();
+  }
+
+  function showError(jqXHR, textStatus, errorThrown) {
+    $('#upload-btn').html('{{ Lang::get("laravel-filemanager::lfm.btn-upload") }}');
+    if (jqXHR.status == 413) {
+      notify('{{ Lang::get("laravel-filemanager::lfm.error-too-large") }}');
+    } else if (textStatus == 'error') {
+      notify('{{ Lang::get("laravel-filemanager::lfm.error-other") }}' + errorThrown);
+    } else {
+      notify('{{ Lang::get("laravel-filemanager::lfm.error-other") }}' + textStatus + '<br>' + errorThrown);
+    }
   }
 
   $('#uploadForm').ajaxSubmit(options);


### PR DESCRIPTION
When an error occurs after a file is uploaded, nothing happens.
My change adds an error handler with a simple message and a custom message for the "Request entity too large" error.
Also i corrected double file extensions in config.