### PR TITLE
add support for the Hebrew language

### DIFF
--- a/src/lang/he/lfm.php
+++ b/src/lang/he/lfm.php
@@ -1,0 +1,63 @@
+<?php
+
+return [
+    'nav-back'          => 'חזרה',
+    'nav-new'           => 'תיקייה חדשה',
+    'nav-upload'        => 'העלה',
+    'nav-thumbnails'    => 'תמונות ממוזערות',
+    'nav-list'          => 'רשימה',
+
+    'menu-rename'       => 'שנה שם',
+    'menu-delete'       => 'מחק',
+    'menu-view'         => 'צפה',
+    'menu-download'     => 'הורד',
+    'menu-resize'       => 'שנה גודל',
+    'menu-crop'         => 'חתוך',
+
+    'title-page'        => 'מנהל קבצים',
+    'title-panel'       => 'מנהל קבצים',
+    'title-upload'      => 'העלאת קובץ',
+    'title-view'        => 'צפייה בקובץ',
+    'title-root'        => 'קבצים',
+    'title-shares'      => 'קבצים משותפים',
+    'title-item'        => 'פריט',
+    'title-size'        => 'גודל',
+    'title-type'        => 'סוג',
+    'title-modified'    => 'שונה',
+    'title-action'      => 'פעולה',
+
+    'type-folder'       => 'תיקייה',
+
+    'message-empty'     => 'התיקייה ריקה.',
+    'message-choose'    => 'בחר קובץ',
+    'message-delete'    => 'האם אתה בטוח שברצונך למחוק פריט זה?',
+    'message-name'      => 'שם התיקייה:',
+    'message-rename'    => 'שם חדש:',
+
+    'error-rename'      => 'הקובץ נמצא בשימוש!',
+    'error-file-empty'  => 'עליך לבחור קובץ!',
+    'error-file-exist'  => 'קובץ עם שם זה כבר קיים!',
+    'error-delete'      => 'לא ניתן למחוק תייקיה זו מכיוון שהיא לא ריקה!',
+    'error-folder-name' => 'נא להזין שם תיקייה!',
+    'error-folder-exist'=> 'תיקייה עם שם זהה כבר קיימת!',
+    'error-mime'        => 'סוג קובץ לא תקין: ',
+    'error-instance'    => 'הקובץ שהועלה צריך להיות מופע של UploadedFile',
+    'error-invalid'     => 'בקשת העלה לא תיקנית.',
+
+    'btn-upload'        => 'העלה קובת',
+    'btn-uploading'     => 'מעלה...',
+    'btn-close'         => 'סגור',
+    'btn-crop'          => 'חתוך',
+    'btn-cancel'        => 'בטל',
+    'btn-resize'        => 'שנה גודל',
+
+    'resize-ratio'      => 'יחס:',
+    'resize-scaled'     => 'תמונה הוגדלה:',
+    'resize-true'       => 'כן',
+    'resize-old-height' => 'גובה מקורי:',
+    'resize-old-width'  => 'אורך מקורי:',
+    'resize-new-height' => 'גובה:',
+    'resize-new-width'  => 'אורך:',
+
+    'locale-bootbox'    => 'he',
+];


### PR DESCRIPTION
Hey.

I've seen that there are several translation but not a Hebrew one.
I thought it would be nice if there was one.

Please do note, Hebrew is an RTL language. I didn't see any way to specify that so I guess the package is LTR only. The hebrew is still fine. 
I suppose Hebrew speakers would prefer the LTR Hebrew version than the English version.

I didn't change the README file, I will let you do that.