### PR TITLE
Choose list or gridview for the filemanager using a config variable

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -24,6 +24,7 @@ return [
     // The database field to identify a user.
     // When set to 'id', the private folder will be named as the user id.
     // NOTE: make sure to use an unique field.
+    // When choosing a startup view you can fill either 'grid' or 'list'.
     'user_field'            => 'id',
 
     'shared_folder_name'    => 'shares',
@@ -31,9 +32,11 @@ return [
 
     'images_dir'            => 'public/photos/',
     'images_url'            => '/photos/',
+    'images_startup_view'   => 'list',
 
     'files_dir'             => 'public/files/',
     'files_url'             => '/files/',
+    'files_startup_view'    => 'grid',
 
     'max_image_size' => 500,
     'max_file_size' => 1000,

--- a/src/controllers/LfmController.php
+++ b/src/controllers/LfmController.php
@@ -17,6 +17,7 @@ class LfmController extends Controller {
     public $file_location = null;
     public $dir_location = null;
     public $file_type = null;
+    public $startup_view = null;
     protected $user;
 
     /**
@@ -29,9 +30,11 @@ class LfmController extends Controller {
         if ('Images' === $this->file_type) {
             $this->dir_location = Config::get('lfm.images_url');
             $this->file_location = Config::get('lfm.images_dir');
+            $this->startup_view = Config::get('lfm.images_startup_view');
         } elseif ('Files' === $this->file_type) {
             $this->dir_location = Config::get('lfm.files_url');
             $this->file_location = Config::get('lfm.files_dir');
+            $this->startup_view = Config::get('lfm.files_startup_view');
         } else {
             throw new \Exception('unexpected type parameter');
         }
@@ -57,6 +60,7 @@ class LfmController extends Controller {
         return view('laravel-filemanager::index')
             ->with('working_dir', $working_dir)
             ->with('file_type', $this->file_type)
+            ->with('startup_view', $this->startup_view)
             ->with('extension_not_found', $extension_not_found);
     }
 

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -119,7 +119,7 @@
               </div>
             </div>
             <input type='hidden' name='working_dir' id='working_dir' value='{{$working_dir}}'>
-            <input type='hidden' name='show_list' id='show_list' value='0'>
+            <input type='hidden' name='show_list' id='show_list' value='{{ ($startup_view == 'list') ? 1 : 0 }}'>
             <input type='hidden' name='type' id='type' value='{{$file_type}}'>
             <input type='hidden' name='_token' value='{{csrf_token()}}'>
           </form>


### PR DESCRIPTION
Added config variables so a user can choose to load the image and file manager in a grid or listview. This provides a cleaner solution than to manually fire a click event on the list button when the page is loaded.

I was planning to do this for some time now. The issue below reminded me that having this small feature might be useful: 
https://github.com/UniSharp/laravel-filemanager/issues/147#issuecomment-263456975

Thanks for creating this amazing package, I use it all the time!
Cheers!