### PR TITLE
Laravel 5.4 fix

### DIFF
--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -44,7 +44,7 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['laravel-filemanager'] = $this->app->share(function ()
+        $this->app->singleton('laravel-filemanager', function ()
         {
             return true;
         });


### PR DESCRIPTION
Using singleton method instead share method. Share method is now deprecated.