### PR TITLE
Laravel 5.4 upgrade

### DIFF
--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -44,7 +44,7 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['laravel-filemanager'] = $this->app->share(function ()
+        $this->app->singleton('filemanager',function ()
         {
             return true;
         });


### PR DESCRIPTION
The singleton method is compatible with 5.4 instead of removing the share method.