### PR TITLE
Added php.ini override feature as configuration option

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -150,4 +150,17 @@ return [
         'ppt'  => 'fa-file-powerpoint-o',
         'pptx' => 'fa-file-powerpoint-o',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | php.ini override
+    |--------------------------------------------------------------------------
+    */
+    // These values override your php.ini settings before uploading files
+    // Set these to false to ingnore and apply your php.ini settings
+    'php_ini_overrides' => [
+        'upload_max_filesize' => '30M',
+        'memory_limit'        => '256M'
+    ]
+
 ];

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -159,7 +159,6 @@ return [
     // These values override your php.ini settings before uploading files
     // Set these to false to ingnore and apply your php.ini settings
     'php_ini_overrides' => [
-        'upload_max_filesize' => '30M',
         'memory_limit'        => '256M'
     ]
 

--- a/src/controllers/LfmController.php
+++ b/src/controllers/LfmController.php
@@ -14,6 +14,8 @@ class LfmController extends Controller
 
     public function __construct()
     {
+        $this->applyIniOverrides();
+        
         if (!$this->isProcessingImages() && !$this->isProcessingFiles()) {
             throw new \Exception('unexpected type parameter');
         }

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -235,6 +235,13 @@ trait LfmHelpers
     {
         return config('lfm.allow_share_folder') === true;
     }
+    
+    public function applyIniOverrides()
+    {
+        foreach (config('lfm.php_ini_overrides') as $key => $value) {
+            if ($value && $value != 'false') ini_set($key, $value);
+        }
+    }
 
 
     /****************************


### PR DESCRIPTION
The added array in the config file applies ini_set() configuration rules in the LfmController constructor.

This helps users who can't  edit php.ini config because of hosting restrictions. Php memory can be temporarily heightened so the problem in [this issue](https://github.com/UniSharp/laravel-filemanager/issues/268) might be prevented.

Any other php.ini configuration can also be edited using this feature, just add the key and value to the php_ini_overrides part of the configuration file.

There are some limitations tough, for example when editing the upload_max_filesize since the request with uploaded files are already received before the setting is edited.

With this implementation the overrides are applied on every class that implements the LfmController. What do you think? Suggestions and improvements are welcome!