### PR TITLE
fix hard coded prefix

### DIFF
--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -110,7 +110,7 @@ trait LfmHelpers
         }
 
         if ($type === 'url' && $base_directory !== 'public') {
-            $prefix = 'laravel-filemanager/' . $prefix;
+            $prefix = config('lfm.prefix', 'laravel-filemanager') . '/' . $prefix;
         }
 
         return $prefix;


### PR DESCRIPTION
# fix hard coded prefix
fix: when default prefix value changed in file “config/lfm.php”,the generated file url will be inaccessible #288 