### PR TITLE
Changed path() method to getRealPath()

### DIFF
--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -61,8 +61,8 @@ class UploadController extends LfmController
 
                 $this->makeThumb($new_filename);
             } else {
-                chmod($file->path(), 0644); // TODO configurable
-                File::move($file->path(), $new_file_path);
+                chmod($file->getRealPath(), 0644); // TODO configurable
+                File::move($file->getRealPath(), $new_file_path);
             }
         } catch (\Exception $e) {
             return parent::error('invalid');


### PR DESCRIPTION
Uploading a regular file using laravel-filemanager causes this error:
`Call to undefined method Symfony\Component\HttpFoundation\File\UploadedFile::path()`

According to other places inside the code, the correct method should be `getRealPath()`, after changing both references in the UploadController I was able to upload files without issues. The error only occured when uploading using the "Files" type of the file manager (like a PDF).