### PR TITLE
Open files without editor

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -320,8 +320,8 @@ function useFile(file_url) {
       window.close();
     }
   } else {
-    // No WYSIWYG editor found, use custom method.
-    window.opener.SetUrl(url, file_path);
+    // No editor found, open/download file using browser's default method
+    window.open(url);
   }
 }
 //end useFile


### PR DESCRIPTION
Fixes #304 

If the file manager is implemented without an editor and does not open a
new popup window (ie. just using as a file browser/upload/download app),
open files using browser's default method instead of trying to access
window.opener (which does not exist). 