### PR TITLE
Auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,16 @@
       "Unisharp\\Laravelfilemanager\\": "src/"
     }
   },
-  "bin": ["bin/debug"]
+  "bin": ["bin/debug"],
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Unisharp\\Laravelfilemanager\\LaravelFilemanagerServiceProvider",
+        "Intervention\\Image\\ImageServiceProvider"
+      ],
+      "aliases": {
+        "Image": "Intervention\\Image\\Facades\\Image"
+      }
+    }
+  }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,8 @@
 
 1. Edit `config/app.php` :
 
+    \* *For Laravel 5.5 and up, skip to step 3. All service providers and facades are automatically discovered.* 
+
     Add service providers
 
     ```php


### PR DESCRIPTION
This PR adds package auto discovery for Laravel 5.5 and up.
Adding service providers and class aliases to config/app.php is no longer necessary if on L5.5