### PR TITLE
Fix for #307

### DIFF
--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -110,7 +110,7 @@ trait LfmHelpers
         }
 
         if ($type === 'url' && $base_directory !== 'public') {
-            $prefix = config('lfm.prefix', 'laravel-filemanager') . '/' . $prefix;
+            $prefix = config('lfm.urls_prefix', 'laravel-filemanager') . '/' . $prefix;
         }
 
         return $prefix;


### PR DESCRIPTION
The problem here is that when its resolving the path for an URL it uses the wrong prefix setting. 
It uses the prefix setting for the laravel-filemanager package. While it should use the urls_prefix setting.