### PR TITLE
Thumbs

### DIFF
--- a/public/css/lfm.css
+++ b/public/css/lfm.css
@@ -137,3 +137,13 @@
   display: inline-block;
   vertical-align: middle;
 }
+
+.table-list-view{
+  margin-bottom: 120px;
+}
+.table-list-view .actions{
+  text-align: right;
+}
+.table-list-view .actions a:hover{
+  text-decoration: none;
+}

--- a/public/css/lfm.css
+++ b/public/css/lfm.css
@@ -112,3 +112,28 @@
 .caption > .btn-group > .dropdown-toggle {
   width: 25px;
 }
+
+#lfm-loader{
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: gray;
+  opacity: 0.7;
+  z-index: 9999;
+  text-align: center;
+}
+#lfm-loader:before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  height: 100%;
+}
+#lfm-loader img{
+  width: 100px;
+  margin: 0 auto;
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/public/img/loader.svg
+++ b/public/img/loader.svg
@@ -1,0 +1,33 @@
+<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
+<svg width="120" height="30" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+    <circle cx="15" cy="15" r="15">
+        <animate attributeName="r" from="15" to="15"
+                 begin="0s" dur="0.8s"
+                 values="15;9;15" calcMode="linear"
+                 repeatCount="indefinite" />
+        <animate attributeName="fill-opacity" from="1" to="1"
+                 begin="0s" dur="0.8s"
+                 values="1;.5;1" calcMode="linear"
+                 repeatCount="indefinite" />
+    </circle>
+    <circle cx="60" cy="15" r="9" fill-opacity="0.3">
+        <animate attributeName="r" from="9" to="9"
+                 begin="0s" dur="0.8s"
+                 values="9;15;9" calcMode="linear"
+                 repeatCount="indefinite" />
+        <animate attributeName="fill-opacity" from="0.5" to="0.5"
+                 begin="0s" dur="0.8s"
+                 values=".5;1;.5" calcMode="linear"
+                 repeatCount="indefinite" />
+    </circle>
+    <circle cx="105" cy="15" r="15">
+        <animate attributeName="r" from="15" to="15"
+                 begin="0s" dur="0.8s"
+                 values="15;9;15" calcMode="linear"
+                 repeatCount="indefinite" />
+        <animate attributeName="fill-opacity" from="1" to="1"
+                 begin="0s" dur="0.8s"
+                 values="1;.5;1" calcMode="linear"
+                 repeatCount="indefinite" />
+    </circle>
+</svg>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -191,6 +191,7 @@ function loadFolders() {
 }
 
 function loadItems() {
+  $('#lfm-loader').show();
   performLfmRequest('jsonitems', {show_list: show_list, sort_type: sort_type}, 'html')
     .done(function (data) {
       var response = JSON.parse(data);
@@ -205,6 +206,9 @@ function loadItems() {
         $('#to-previous').removeClass('hide');
       }
       setOpenFolders();
+    })
+    .always(function(){
+      $('#lfm-loader').hide();
     });
 }
 

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -95,12 +95,21 @@ return [
         'image/svg+xml',
     ],
 
-    // Create thumbnails automatically only for listed types. Make this array empty to disable creating any thumbnails
-    'thumb_mimetypes' => [
+    // If true, image thumbnails would be created during upload
+    'should_create_thumbnails' => true,
+
+    // Create thumbnails automatically only for listed types.
+    'raster_mimetypes' => [
         'image/jpeg',
         'image/pjpeg',
         'image/png',
     ],
+
+    // permissions to be set when create a new folder or when it creates automatically with thumbnails
+    'create_folder_mode' => 0755,
+
+    // permissions to be set on file upload.
+    'create_file_mode' => 0644,
 
     // available since v1.3.0
     // only when '/laravel-filemanager?type=Files'

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -95,6 +95,13 @@ return [
         'image/svg+xml',
     ],
 
+    // Create thumbnails automatically only for listed types. Make this array empty to disable creating any thumbnails
+    'thumb_mimetypes' => [
+        'image/jpeg',
+        'image/pjpeg',
+        'image/png',
+    ],
+
     // available since v1.3.0
     // only when '/laravel-filemanager?type=Files'
     'valid_file_mimetypes' => [

--- a/src/controllers/CropController.php
+++ b/src/controllers/CropController.php
@@ -49,10 +49,16 @@ class CropController extends LfmController
             ->crop($dataWidth, $dataHeight, $dataX, $dataY)
             ->save($crop_path);
 
-        // make new thumbnail
-        Image::make($crop_path)
-            ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200))
-            ->save(parent::getThumbPath(parent::getName($crop_path)));
+        if (config('lfm.should_create_thumbnails')) {
+            // create thumb folder
+            parent::createFolderByPath(parent::getThumbPath());
+
+            // make new thumbnail
+            Image::make($crop_path)
+                ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200))
+                ->save(parent::getThumbPath(parent::getName($crop_path)));
+        }
+
         event(new ImageWasCropped($image_path));
     }
 

--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -63,7 +63,7 @@ class UploadController extends LfmController
                 $this->makeThumb($new_filename);
             }
             {
-                chmod($file->getRealPath(), 0644); // TODO configurable
+                chmod($file->getRealPath(), config('lfm.create_file_mode', 0644));
                 File::move($file->getRealPath(), $new_file_path);
             }
         } catch (\Exception $e) {

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -257,7 +257,7 @@ trait LfmHelpers
      */
     private function removeDuplicateSlash($path)
     {
-        return str_replace($this->ds . $this->ds, $this->ds, $path);
+        return preg_replace('/\\'.$this->ds.'{2,}/', $this->ds, $path);
     }
 
     /**
@@ -530,9 +530,8 @@ trait LfmHelpers
     public function imageShouldNotHaveThumb($file)
     {
         $mine_type = $this->getFileType($file);
-        $noThumbType = ['image/gif', 'image/svg+xml'];
 
-        return in_array($mine_type, $noThumbType);
+        return !in_array($mine_type, config('lfm.thumb_mimetypes'));
     }
 
     /**

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -529,8 +529,9 @@ trait LfmHelpers
      */
     public function imageShouldNotHaveThumb($file)
     {
-        if (! config('lfm.should_create_thumbnails'))
+        if (! config('lfm.should_create_thumbnails')) {
             return true;
+        }
 
         $mime_type = $this->getFileType($file);
 

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -493,7 +493,7 @@ trait LfmHelpers
     public function createFolderByPath($path)
     {
         if (! File::exists($path)) {
-            File::makeDirectory($path, 0777, true, true);
+            File::makeDirectory($path, config('lfm.create_folder_mode', 0755), true, true);
         }
     }
 
@@ -529,9 +529,12 @@ trait LfmHelpers
      */
     public function imageShouldNotHaveThumb($file)
     {
-        $mine_type = $this->getFileType($file);
+        if (!config('lfm.should_create_thumbnails'))
+            return true;
 
-        return !in_array($mine_type, config('lfm.thumb_mimetypes'));
+        $mime_type = $this->getFileType($file);
+
+        return ! in_array($mime_type, config('lfm.raster_mimetypes'));
     }
 
     /**

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -529,7 +529,7 @@ trait LfmHelpers
      */
     public function imageShouldNotHaveThumb($file)
     {
-        if (!config('lfm.should_create_thumbnails'))
+        if (! config('lfm.should_create_thumbnails'))
             return true;
 
         $mime_type = $this->getFileType($file);

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -141,6 +141,10 @@
     </div>
   </div>
 
+  <div id="lfm-loader">
+    <img src="{{asset('vendor/laravel-filemanager/img/loader.svg')}}">
+  </div>
+
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
   <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/bootbox.js/4.4.0/bootbox.min.js"></script>

--- a/src/views/list-view.blade.php
+++ b/src/views/list-view.blade.php
@@ -1,5 +1,5 @@
 @if((sizeof($files) > 0) || (sizeof($directories) > 0))
-<table class="table table-responsive table-condensed table-striped hidden-xs">
+<table class="table table-responsive table-condensed table-striped hidden-xs table-list-view">
   <thead>
     <th style='width:50%;'>{{ Lang::get('laravel-filemanager::lfm.title-item') }}</th>
     <th>{{ Lang::get('laravel-filemanager::lfm.title-size') }}</th>
@@ -12,27 +12,36 @@
     <tr>
       <td>
         <i class="fa {{ $item->icon }}"></i>
-        <a class="{{ $item->is_file ? 'file' : 'folder'}}-item clickable" data-id="{{ $item->is_file ? $item->url : $item->path }}">
-          {{ str_limit($item->name, $limit = 20, $end = '...') }}
+        <a class="{{ $item->is_file ? 'file' : 'folder'}}-item clickable" data-id="{{ $item->is_file ? $item->url : $item->path }}" title="{{$item->name}}">
+          {{ str_limit($item->name, $limit = 40, $end = '...') }}
         </a>
       </td>
       <td>{{ $item->size }}</td>
       <td>{{ $item->type }}</td>
       <td>{{ $item->time }}</td>
-      <td>
+      <td class="actions">
         @if($item->is_file)
-        <a href="javascript:trash('{{ $item->name }}')">
+          <a href="javascript:download('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-download') }}">
+            <i class="fa fa-download fa-fw"></i>
+          </a>
+          @if($item->thumb)
+            <a href="javascript:fileView('{{ $item->url }}', '{{ $item->updated }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-view') }}">
+              <i class="fa fa-image fa-fw"></i>
+            </a>
+            <a href="javascript:cropImage('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-crop') }}">
+              <i class="fa fa-crop fa-fw"></i>
+            </a>
+            <a href="javascript:resizeImage('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-resize') }}">
+              <i class="fa fa-arrows fa-fw"></i>
+            </a>
+          @endif
+        @endif
+        <a href="javascript:rename('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-rename') }}">
+          <i class="fa fa-edit fa-fw"></i>
+        </a>
+        <a href="javascript:trash('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-delete') }}">
           <i class="fa fa-trash fa-fw"></i>
         </a>
-        @if($item->thumb)
-        <a href="javascript:cropImage('{{ $item->name }}')">
-          <i class="fa fa-crop fa-fw"></i>
-        </a>
-        <a href="javascript:resizeImage('{{ $item->name }}')">
-          <i class="fa fa-arrows fa-fw"></i>
-        </a>
-        @endif
-        @endif
       </td>
     </tr>
     @endforeach


### PR DESCRIPTION
Added config lfm.thumb_mimetypes to define which image types should create thumbnails automatically. This config was added to let user define which file type shoud have a thumbnail. Also you can make this config array empty, so thumbnails would never be created.

removeDuplicateSlash function was rebuild to replace 2 or more slashes by one. Original function was replacing only 2 slashes by one, like so: "mydir///my-subdir" would return "mydir//my-subdir". 

Added animation loader. Very useful feature when you are trying to open directory with many files inside. It could take long time like 5-10 seconds to open that directory. Hard to understand what's going on if you have no loader. You just click some folder and nothing happens.