### PR TITLE
Corrected returned file creation time

### DIFF
--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -476,7 +476,7 @@ trait LfmHelpers
             'size'    => $is_file ? $this->humanFilesize(File::size($item)) : '',
             'updated' => filemtime($item),
             'path'    => $is_file ? '' : $this->getInternalPath($item),
-            'time'    => date('Y-m-d h:m', filemtime($item)),
+            'time'    => date('Y-m-d h:i', filemtime($item)),
             'type'    => $file_type,
             'icon'    => $icon,
             'thumb'   => $thumb_url,


### PR DESCRIPTION
Corrected returned file creation time to 'Y-m-d h:i'. See Issue #417