### PR TITLE
json output for ckeditor drag&drop

### DIFF
--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -190,7 +190,7 @@ class UploadController extends LfmController
         $file = parent::getFileUrl($new_filename);
 
         $responseType=request()->input('responseType');
-        if ($responseType && $responseType=='json'){
+        if ($responseType && $responseType=='json') {
             return [
                 "uploaded"=> 1,
                 "fileName"=> $new_filename,

--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -189,6 +189,15 @@ class UploadController extends LfmController
     {
         $file = parent::getFileUrl($new_filename);
 
+        $responseType=request()->input('responseType');
+        if ($responseType && $responseType=='json'){
+            return [
+                "uploaded"=> 1,
+                "fileName"=> $new_filename,
+                "url"=> $file,
+            ];
+        }
+
         return "<script type='text/javascript'>
 
         function getUrlParam(paramName) {


### PR DESCRIPTION
i just added a little fix to return a json response required by ckeditor drag&drop image upload. to dont break anything its necesary add the `responseType=json ` argument to the uploadUrl option.

something like:
```
{
   uploadUrl: route_prefix + '/upload?type=Images&responseType=json&_token='
}
```