### PR TITLE
Prevent Container::make() from type-hinting the parameters

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -120,7 +120,7 @@ class LfmPath
         $lfm_path = clone $this;
         $lfm_path = $lfm_path->setName($this->helper->getNameFromPath($item_path));
 
-        return Container::getInstance()->make(LfmItem::class, [$lfm_path, $this->helper]);
+        return Container::getInstance()->makeWith(LfmItem::class, ['lfm' => $lfm_path, 'helper' => $this->helper]);
     }
 
     public function delete()


### PR DESCRIPTION
I was having a hell of a time getting `jsonitems` to return any legitimate output. I am using Laravel 5.4.

The issue happens in `LfmPath::pretty()` when it attempts to resolve a new `LfmItem` instance.

```php
return Container::getInstance()->make(LfmItem::class, [$lfm_path, $this->helper]);
```

The problem is that in Laravel 5.4 the `Container::make()` method does not accept the parameters as an argument. You instead have to use `Container::makeWith()`. `Container::make()` was changed in Laravel 5.5 to behave exactly the same as `Container::makeWith()`, so changing the method to `makeWith()` ensures backwards compatibility.

![image](https://user-images.githubusercontent.com/6479817/34605513-c23661b4-f1c0-11e7-9372-30c790678234.png)

The second problem is that the `Container::makeWith()` method does not accept a non-associate array for the parameters. You instead have to pass an associative array with keys as the dependency name. See https://github.com/laravel/framework/issues/18474. 

We end up with this:
```php
return Container::getInstance()->makeWith(LfmItem::class, ['lfm' => $lfm_path, 'helper' => $this->helper]);
```

The code still actually ran before, because laravel simply type-hinted the `LfmPath` object instead of creating it from the parameters. This however, meant that the data was getting wiped as it was getting passed through this function. 
