### PR TITLE
Cast the thumbnail object to a string when saving

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -321,6 +321,6 @@ class LfmPath
             ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200))
             ->encode();
 
-        $this->setName($file_name)->thumb(true)->storage->save($image_content);
+        $this->setName($file_name)->thumb(true)->storage->save((string) $image_content);
     }
 }


### PR DESCRIPTION
I encountered an issue within `LfmPath::makeThumbnail()`. 

```php
// generate cropped image content
$image_content = Image::make($original_image->get())
    ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200))
    ->encode();

$this->setName($file_name)->thumb(true)->storage->save($image_content);
```
`Image::encode()` returns an instance of `Intervention\Image\Image` with attached encoded image data. It then needs to be casted to a string to access the data. For some reason, it is not automatically cast when passed to the `save()` method causing it throw an error.

```
[2018-01-05 10:04:15] dev.ERROR: fstat() expects parameter 1 to be resource, object given {"file":"/home/vagrant/foundation/vendor/league/flysystem/src/Util.php","line":271,"trace":"#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(2, 'fstat() expects...', '/home/vagrant/f...', 271, Array)
#1 /home/vagrant/foundation/vendor/league/flysystem/src/Util.php(271): fstat(Object(Intervention\\Image\\Image))
#2 /home/vagrant/foundation/vendor/league/flysystem-aws-s3-v3/src/AwsS3Adapter.php(576): League\\Flysystem\\Util::getStreamSize(Object(Intervention\\Image\\Image))
#3 /home/vagrant/foundation/vendor/league/flysystem-aws-s3-v3/src/AwsS3Adapter.php(121): League\\Flysystem\\AwsS3v3\\AwsS3Adapter->upload('filemanager/ima...', Object(Intervention\\Image\\Image), Object(League\\Flysystem\\Config))
#4 /home/vagrant/foundation/vendor/league/flysystem/src/Filesystem.php(102): League\\Flysystem\\AwsS3v3\\AwsS3Adapter->write('filemanager/ima...', Object(Intervention\\Image\\Image), Object(League\\Flysystem\\Config))
#5 /home/vagrant/foundation/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php(133): League\\Flysystem\\Filesystem->put('filemanager/ima...', Object(Intervention\\Image\\Image), Object(League\\Flysystem\\Config))
#6 /home/vagrant/foundation/vendor/unisharp/laravel-filemanager/src/LfmStorageRepository.php(47): Illuminate\\Filesystem\\FilesystemAdapter->put('filemanager/ima...', Object(Intervention\\Image\\Image))
#7 /home/vagrant/foundation/vendor/unisharp/laravel-filemanager/src/LfmPath.php(300): UniSharp\\LaravelFilemanager\\LfmStorageRepository->save(Object(Intervention\\Image\\Image))
#8 /home/vagrant/foundation/vendor/unisharp/laravel-filemanager/src/LfmPath.php(279): UniSharp\\LaravelFilemanager\\LfmPath->makeThumbnail('nikita240_full....')
#9 /home/vagrant/foundation/vendor/unisharp/laravel-filemanager/src/LfmPath.php(207): UniSharp\\LaravelFilemanager\\LfmPath->saveFile(Object(Illuminate\\Http\\UploadedFile), 'nikita240_full....')
#10 /home/vagrant/foundation/vendor/unisharp/laravel-filemanager/src/controllers/UploadController.php(34): UniSharp\\LaravelFilemanager\\LfmPath->upload(Object(Illuminate\\Http\\UploadedFile))
#11 [internal function]: UniSharp\\LaravelFilemanager\\controllers\\UploadController->upload()
```

The fix is just to cast it manually.

```php
$this->setName($file_name)->thumb(true)->storage->save((string) $image_content);
```