### PR TITLE
Added support for arbitrary callback

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -447,14 +447,21 @@ function use(item) {
 
   var url = item.url;
   var field_name = getUrlParam('field_name');
+  var callback = getUrlParam('callback');
   var is_ckeditor = getUrlParam('CKEditor');
   var is_fcke = typeof data != 'undefined' && data['Properties']['Width'] != '';
 
-  if (window.opener || window.tinyMCEPopup || field_name || getUrlParam('CKEditorCleanUpFuncNum') || is_ckeditor) {
+  if (window.opener || window.tinyMCEPopup || field_name || callback || getUrlParam('CKEditorCleanUpFuncNum') || is_ckeditor) {
     if (window.tinyMCEPopup) { // use TinyMCE > 3.0 integration method
       useTinymce3(url);
     } else if (field_name) {   // tinymce 4 and colorbox
       useTinymce4AndColorbox(url, field_name);
+    } else if (callback && (window[callback] || parent[callback])) {
+      if (window[callback]) {
+        window[callback](getSelectedItems());
+      } else if (parent[callback]) {
+        parent[callback](getSelecteditems());
+      }
     } else if(is_ckeditor) {   // use CKEditor 3.0 + integration method
       useCkeditor3(url);
     } else if (is_fcke) {      // use FCKEditor 2.0 integration method


### PR DESCRIPTION
This allows you to integrate this with Fancybox or other lightboxes / iframe embeds.

To integrate with Fancybox 3, modify "stand-along-button.js" and remove the call to `window.open()` and replace it with:

    $.fancybox.open({
        src: route_prefix + '?type=' + type + '&callback=SetUrl',
        type: 'iframe',
        opts: {
            iframe: {
                css: {
                    width: '900px',
                    height: '600px'
                }
            }
        }
    });

# Warning: I did not test this!

Not even sure if this is the correct way of going about doing this. At best, think of it as an example. I modified the 1.8 version in my current project with similar changes and everything works well, but I don't have the requisite knowledge to know if I'm breaking something.

