### PR TITLE
Added an url_prefix setting

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -44,6 +44,9 @@ return [
     // Which folder to store files in project, fill in 'public', 'resources', 'storage' and so on.
     // You should create routes to serve images if it is not set to public.
     'base_directory' => 'public',
+    
+    // A prefix added to the URL of images and files
+    'url_prefix' => '',
 
     'images_folder_name' => 'photos',
     'files_folder_name'  => 'files',

--- a/src/traits/LfmHelpers.php
+++ b/src/traits/LfmHelpers.php
@@ -63,7 +63,7 @@ trait LfmHelpers
      */
     public function getFileUrl($image_name = null, $is_thumb = null)
     {
-        return url($this->composeSegments('url', $is_thumb, $image_name));
+        return url(config('lfm.url_prefix') . $this->composeSegments('url', $is_thumb, $image_name));
     }
 
     /**


### PR DESCRIPTION
Not sure if this is worth merging (perhaps I simply missed anything in the docs/configuration), but I ran into a situation where the URL's returned by LFM weren't correct. Belows are the steps to reproduce and a PR fixing this issue.

### Steps to reproduce

- Setting base_directory to `storage/app/public`
- Leave images_folder_name and files_folder_name to defaults
- Create the default symlink in Laravel using `php artisan storage:link`
- Upload an image using the editor
- Insert an image in CKEditor or any editor of choice

### The problem

The full URL to the image being returned ends up being `http://yoursite.com/photos/1/12345.jpg` for example. While the generated symlink expects the URL to be `http://yoursite.com/storage/photos/1/123456.jpg`.

### The suggested fix (in the PR)

- Adding a `url_prefix` setting to the configuration file
- Setting the value of `url_prefix` to (in this case) `"storage"`
- Get the `getFileUrl()`method in LfmHelpers.php to prefix the URL using the `url_prefix` configuration value
- End up having the correct link