### PR TITLE
Allow the use of single quotes in names

### DIFF
--- a/src/views/grid-view.blade.php
+++ b/src/views/grid-view.blade.php
@@ -9,8 +9,8 @@
     <?php $item_path = $item->is_file ? $item->url : $item->path; ?>
 
     <div class="square clickable {{ $item->is_file ? '' : 'folder-item' }}" data-id="{{ $item_path }}"
-           @if($item->is_file && $thumb_src) onclick="useFile('{{ $item_path }}', '{{ $item->updated }}')"
-           @elseif($item->is_file) onclick="download('{{ $item_name }}')" @endif >
+           @if($item->is_file && $thumb_src) onclick="useFile({{ json_encode($item_path) }}, '{{ $item->updated }}')"
+           @elseif($item->is_file) onclick="download({{ json_encode($item_name) }})" @endif >
       @if($thumb_src)
       <img src="{{ $thumb_src }}">
       @else
@@ -22,8 +22,8 @@
       <div class="btn-group">
         <button type="button" data-id="{{ $item_path }}"
                 class="item_name btn btn-default btn-xs {{ $item->is_file ? '' : 'folder-item'}}"
-                @if($item->is_file && $thumb_src) onclick="useFile('{{ $item_path }}', '{{ $item->updated }}')"
-                @elseif($item->is_file) onclick="download('{{ $item_name }}')" @endif >
+                @if($item->is_file && $thumb_src) onclick="useFile({{ json_encode($item_path) }}, '{{ $item->updated }}')"
+                @elseif($item->is_file) onclick="download({{ json_encode($item_name) }})" @endif >
           {{ $item_name }}
         </button>
         <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown" aria-expanded="false">
@@ -31,18 +31,18 @@
           <span class="sr-only">Toggle Dropdown</span>
         </button>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="javascript:rename('{{ $item_name }}')"><i class="fa fa-edit fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-rename') }}</a></li>
+          <li><a href="javascript:rename({{ json_encode($item_name) }})"><i class="fa fa-edit fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-rename') }}</a></li>
           @if($item->is_file)
-          <li><a href="javascript:download('{{ $item_name }}')"><i class="fa fa-download fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-download') }}</a></li>
+          <li><a href="javascript:download({{ json_encode($item_name) }})"><i class="fa fa-download fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-download') }}</a></li>
           <li class="divider"></li>
           @if($thumb_src)
-          <li><a href="javascript:fileView('{{ $item_path }}', '{{ $item->updated }}')"><i class="fa fa-image fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-view') }}</a></li>
-          <li><a href="javascript:resizeImage('{{ $item_name }}')"><i class="fa fa-arrows fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-resize') }}</a></li>
-          <li><a href="javascript:cropImage('{{ $item_name }}')"><i class="fa fa-crop fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-crop') }}</a></li>
+          <li><a href="javascript:fileView({{ json_encode($item_path) }}, '{{ $item->updated }}')"><i class="fa fa-image fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-view') }}</a></li>
+          <li><a href="javascript:resizeImage({{ json_encode($item_name) }})"><i class="fa fa-arrows fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-resize') }}</a></li>
+          <li><a href="javascript:cropImage({{ json_encode($item_name) }})"><i class="fa fa-crop fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-crop') }}</a></li>
           <li class="divider"></li>
           @endif
           @endif
-          <li><a href="javascript:trash('{{ $item_name }}')"><i class="fa fa-trash fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-delete') }}</a></li>
+          <li><a href="javascript:trash({{ json_encode($item_name) }})"><i class="fa fa-trash fa-fw"></i> {{ Lang::get('laravel-filemanager::lfm.menu-delete') }}</a></li>
         </ul>
       </div>
     </div>

--- a/src/views/list-view.blade.php
+++ b/src/views/list-view.blade.php
@@ -21,25 +21,25 @@
       <td>{{ $item->time }}</td>
       <td class="actions">
         @if($item->is_file)
-          <a href="javascript:download('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-download') }}">
+          <a href="javascript:download({{ json_encode($item->name) }})" title="{{ Lang::get('laravel-filemanager::lfm.menu-download') }}">
             <i class="fa fa-download fa-fw"></i>
           </a>
           @if($item->thumb)
-            <a href="javascript:fileView('{{ $item->url }}', '{{ $item->updated }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-view') }}">
+            <a href="javascript:fileView({{ json_encode($item->url) }}, '{{ $item->updated }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-view') }}">
               <i class="fa fa-image fa-fw"></i>
             </a>
-            <a href="javascript:cropImage('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-crop') }}">
+            <a href="javascript:cropImage({{ json_encode($item->name) }})" title="{{ Lang::get('laravel-filemanager::lfm.menu-crop') }}">
               <i class="fa fa-crop fa-fw"></i>
             </a>
-            <a href="javascript:resizeImage('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-resize') }}">
+            <a href="javascript:resizeImage({{ json_encode($item->name) }})" title="{{ Lang::get('laravel-filemanager::lfm.menu-resize') }}">
               <i class="fa fa-arrows fa-fw"></i>
             </a>
           @endif
         @endif
-        <a href="javascript:rename('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-rename') }}">
+        <a href="javascript:rename({{ json_encode($item->name) }})" title="{{ Lang::get('laravel-filemanager::lfm.menu-rename') }}">
           <i class="fa fa-edit fa-fw"></i>
         </a>
-        <a href="javascript:trash('{{ $item->name }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-delete') }}">
+        <a href="javascript:trash({{ json_encode($item->name) }})" title="{{ Lang::get('laravel-filemanager::lfm.menu-delete') }}">
           <i class="fa fa-trash fa-fw"></i>
         </a>
       </td>
@@ -70,7 +70,7 @@
                   {{ str_limit($item->name, $limit = 20, $end = '...') }}
                 </a>
                 &nbsp;&nbsp;
-                {{-- <a href="javascript:rename('{{ $item->name }}')">
+                {{-- <a href="javascript:rename({{ json_encode($item->name) }})">
                   <i class="fa fa-edit"></i>
                 </a> --}}
               </p>


### PR DESCRIPTION
As mentioned in #520, using apostrophes in file or directory names results in a JavaScript error:

    Uncaught SyntaxError: missing ) after argument list

However the proposed fix might not handle double quotes, the most reliable way seems to use `json_encode` (see [this SO question](https://stackoverflow.com/questions/6269188/how-do-i-escape-only-single-quotes)).