### PR TITLE
feat(crop): add free crop and add small thumb on list view

### DIFF
--- a/src/views/crop.blade.php
+++ b/src/views/crop.blade.php
@@ -23,9 +23,9 @@
         <label class="btn btn-primary btn-aspectRatio" onclick="changeAspectRatio(this, 2 / 3)">
           2:3
         </label>
-        {{--<label class="btn btn-primary" onclick="changeAspectRatio(this, null)">
+        <label class="btn btn-primary" onclick="changeAspectRatio(this, null)">
           Free
-        </label>--}}
+        </label>
       </div>
       <br>
       <br>

--- a/src/views/list-view.blade.php
+++ b/src/views/list-view.blade.php
@@ -11,7 +11,19 @@
     @foreach($items as $item)
     <tr>
       <td>
-        <i class="fa {{ $item->icon }}"></i>
+        @if($item->is_file)
+        <?php $thumb_src = $item->thumb; ?>
+					@if($thumb_src)
+					<a href="javascript:fileView('{{ $item->url }}', '{{ $item->updated }}')" title="{{ Lang::get('laravel-filemanager::lfm.menu-view') }}">
+					      <img width="40" height="40" src="{{$item->url}}" alt="">
+					    </a>
+					@else
+					<i class="fa {{ $item->icon }} fa-5x"></i>
+		      	@endif
+         @else
+            <i class="fa {{ $item->icon }}"></i>
+        @endif
+
         <a class="{{ $item->is_file ? 'file' : 'folder'}}-item clickable" data-id="{{ $item->is_file ? $item->url : $item->path }}" title="{{$item->name}}">
           {{ str_limit($item->name, $limit = 40, $end = '...') }}
         </a>


### PR DESCRIPTION
I need a free crop. Can you put it back

For best practice, I think we should put a small thumbnail to make user still know what is an image
![image](https://user-images.githubusercontent.com/10907980/42312113-afebe622-8069-11e8-8d75-5b171db0df72.png)
