### PR TITLE
Fix Authorization header.

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -255,7 +255,10 @@ function performLfmRequest(url, parameter, type) {
   return $.ajax({
     type: 'GET',
     beforeSend: function(request) {
-      request.setRequestHeader("Authorization", 'Bearer ' + getUrlParam('token'));
+      var token = getUrlParam('token');
+      if (token !== null) {
+        request.setRequestHeader("Authorization", 'Bearer ' + token);
+      }
     },
     dataType: type || 'text',
     url: lfm_route + '/' + url,


### PR DESCRIPTION
The Authorization header should not be set if the token is not found.

The application can implement different logic when this header is present and when it is not present. For example, when using the [jwt-auth](https://github.com/tymondesigns/jwt-auth) package, you can pass a token through the header and the cookie, but the header has the highest priority. In this case, the presence of the header makes it impossible to parse the token from other places.