### PR TITLE
Download action on single element

### DIFF
--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -201,7 +201,7 @@
         name: 'download',
         icon: 'download',
         label: lang['menu-download'],
-        multiple: true
+        multiple: false
       },
       // {
       //   name: 'preview',


### PR DESCRIPTION
I noticed that the download was not working on my project and I've found that the name attribute could not be found on script.js

`
function download(item) {
    var data = defaultParameters();
    data['file'] = item.name;
    location.href = lfm_route + '/download?' + $.param(data);
}
`
It is because the actions has is defined as multiple on index.blade.php

I'm not sure if the expected behavior is to allow multiple downloads (in which case the modificacion should be to iterate though the items on script.js on the download function) or the fix I'm proposing here
