### PR TITLE
fix a bug in LfmPath::uploadValidator

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -246,7 +246,7 @@ class LfmPath
             throw new \Exception('File failed to upload. Error code: ' . $file->getError());
         }
 
-        $new_file_name = $this->getNewName($file) . '.' . $file->getClientOriginalExtension();
+        $new_file_name = $this->getNewName($file);
 
         if ($this->setName($new_file_name)->exists()) {
             return $this->error('file-exist');


### PR DESCRIPTION
#### Summary of the change: remove duplicate file extension concatenation in [LfmPath::uploadValidator](https://github.com/UniSharp/laravel-filemanager/blob/3602e622bb4ba9f2a1e346af407f180b6ea01d35/src/LfmPath.php#L249)
