### PR TITLE
Support thumbnail creation on non-local filesystems

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -315,6 +315,6 @@ class LfmPath
         $image = Image::make($original_image->get())
             ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200));
 
-        $this->storage->put($image_path, $image->stream()->detach());
+        $this->storage->put($image->stream()->detach());
     }
 }

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -313,7 +313,8 @@ class LfmPath
         // generate cropped image content
         $image_path = $this->setName($file_name)->thumb(true)->path('absolute');
         $image = Image::make($original_image->get())
-            ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200))
-            ->save($image_path);
+            ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200));
+
+        $this->storage->put($image_path, $image->stream()->detach());
     }
 }

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -311,7 +311,7 @@ class LfmPath
         $this->setName(null)->thumb(true)->createFolder();
 
         // generate cropped image content
-        $image_path = $this->setName($file_name)->thumb(true)->path('absolute');
+        $this->setName($file_name)->thumb(true);
         $image = Image::make($original_image->get())
             ->fit(config('lfm.thumb_img_width', 200), config('lfm.thumb_img_height', 200));
 


### PR DESCRIPTION
#### Summary of the change: Support creation of thumbnails when using non-local filesystem drivers

The Intervention `Image::save()` method only supports the local filesystem so it fails if like in my case you are using S3.
I've changed it to use the configured disks storage driver to store the output.