### PR TITLE
Support CacheAdapters

### DIFF
--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -3,6 +3,7 @@
 namespace UniSharp\LaravelFilemanager;
 
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\Cached\CachedAdapter;
 
 class LfmStorageRepository implements RepositoryContract
 {
@@ -25,8 +26,13 @@ class LfmStorageRepository implements RepositoryContract
 
     public function rootPath()
     {
-        // storage_path('app')
-        return $this->disk->getDriver()->getAdapter()->getPathPrefix();
+        $adapter = $this->disk->getDriver()->getAdapter();
+
+        if ($adapter instanceof CachedAdapter) {
+            $adapter = $adapter->getAdapter();
+        }
+
+        return $adapter->getPathPrefix();
     }
 
     public function move($new_lfm_path)


### PR DESCRIPTION
#### Summary of the change: Support CacheAdapters

[Laravel recommends](https://laravel.com/docs/5.7/filesystem#driver-prerequisites) using CachedAdapter from `league/flysystem-cached-adapter` to cache driver meta data.

Prior to this commit it wasn't supported by this package and throws the following exception when attempting to upload a file:

```
Call to undefined method League\Flysystem\Cached\CachedAdapter::getPathPrefix() {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to undefined method League\\Flysystem\\Cached\\CachedAdapter::getPathPrefix() at /SNIP/vendor/unisharp/laravel-filemanager/src/LfmStorageRepository.php:29)
[stacktrace]
#0 /SNIP/vendor/unisharp/laravel-filemanager/src/LfmPath.php(77): UniSharp\\LaravelFilemanager\\LfmStorageRepository->rootPath()
#1 /SNIP/vendor/unisharp/laravel-filemanager/src/LfmPath.php(222): UniSharp\\LaravelFilemanager\\LfmPath->path('absolute')
#2 /SNIP/vendor/unisharp/laravel-filemanager/src/Controllers/UploadController.php(34): UniSharp\\LaravelFilemanager\\LfmPath->upload(Object(Illuminate\\Http\\UploadedFile))
#3 [internal function]: UniSharp\\LaravelFilemanager\\Controllers\\UploadController->upload()
```
The fix in this PR is similar to as used in laravel/framework at https://github.com/laravel/framework/blob/5.7/src/Illuminate/Filesystem/FilesystemAdapter.php#L376-L397 in that it unwraps the CachedAdapter.

It has made a significant improvement to my file listing performance with S3.