### PR TITLE
Fix namespace in LfmConfigHandler

### DIFF
--- a/src/Handlers/LfmConfigHandler.php
+++ b/src/Handlers/LfmConfigHandler.php
@@ -2,7 +2,7 @@
 
 namespace App\Handlers;
 
-class LfmConfigHandler extends \Unisharp\Laravelfilemanager\Handlers\ConfigHandler
+class LfmConfigHandler extends \UniSharp\LaravelFilemanager\Handlers\ConfigHandler
 {
     public function userField()
     {


### PR DESCRIPTION
I got this error when using [**barryvdh/laravel-ide-helper**] to generate phpDoc.

`PHP Fatal error:  Class 'Unisharp\Laravelfilemanager\Handlers\ConfigHandler' not found in C:\....\app\Handlers\LfmConfigHandler.php on line 5`

=> fixed the namespace [ capital S and capital F]