### PR TITLE
escape folder name in delete error handler

### DIFF
--- a/src/Controllers/DeleteController.php
+++ b/src/Controllers/DeleteController.php
@@ -30,7 +30,7 @@ class DeleteController extends LfmController
         }
 
         if (! File::exists($file_to_delete)) {
-            return parent::error('folder-not-found', ['folder' => $file_to_delete]);
+            return parent::error('folder-not-found', ['folder' => htmlspecialchars($file_to_delete)]);
         }
 
         if (File::isDirectory($file_to_delete)) {


### PR DESCRIPTION
#### (optional) Issue number: #787 
#### Summary of the change: escape folder name in delete error handler
