### PR TITLE
Fix trouble with empty folders

### DIFF
--- a/src/LfmItem.php
+++ b/src/LfmItem.php
@@ -65,7 +65,11 @@ class LfmItem
      */
     public function isImage()
     {
-        return starts_with($this->mimeType(), 'image');
+        if (!$this->isDirectory()) {
+            return starts_with($this->mimeType(), 'image');
+        }
+
+        return false;
     }
 
     /**
@@ -105,7 +109,11 @@ class LfmItem
 
     public function time()
     {
-        return $this->lfm->lastModified();
+        if (!$this->isDirectory()) {
+            return $this->lfm->lastModified();
+        }
+
+        return false;
     }
 
     public function thumbUrl()

--- a/tests/LfmItemTest.php
+++ b/tests/LfmItemTest.php
@@ -75,7 +75,8 @@ class LfmItemTest extends TestCase
 
     public function testIsImage()
     {
-        $this->lfm_path->shouldReceive('mimeType')->andReturn('application/plain');
+        $this->lfm_path->shouldReceive('mimeType')->andReturn('application/plain')->shouldReceive('isDirectory')
+            ->andReturn(false);
 
         $item = new LfmItem($this->lfm_path, $this->lfm);
 
@@ -150,7 +151,8 @@ class LfmItemTest extends TestCase
 
     public function testTime()
     {
-        $this->lfm_path->shouldReceive('lastModified')->andReturn(0);
+        $this->lfm_path->shouldReceive('lastModified')->andReturn(0)->shouldReceive('isDirectory')
+            ->andReturn(false);
 
         $item = new LfmItem($this->lfm_path, $this->lfm);
 
@@ -185,7 +187,8 @@ class LfmItemTest extends TestCase
 
     public function testHasThumb()
     {
-        $this->lfm_path->shouldReceive('mimeType')->andReturn('application/plain');
+        $this->lfm_path->shouldReceive('mimeType')->andReturn('application/plain')->shouldReceive('isDirectory')
+            ->andReturn(false);
 
         $item = new LfmItem($this->lfm_path, $this->lfm);
 


### PR DESCRIPTION
> I really need this so as not to override your classes.


The problem is in **empty directories**. 
When creating **folders**, the system does not check that it is a directory and tries to read it as a file. From there, problems arise when building a **tree**.
Every time the same **Exception** `FileNotFoundException`

In this PR i've added 3 checks with **code**:
```php
if (! $this->isDirectory()) {
   //
}
return false;
```