### PR TITLE
don't try to set ACL on directory if filesystem doesn't support them

### DIFF
--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -57,7 +57,11 @@ class LfmStorageRepository
     {
         $this->disk->makeDirectory($this->path, ...func_get_args());
 
-        $this->disk->setVisibility($this->path, 'public');
+        // some filesystems (e.g. Google Storage, S3?) don't let you set ACLs on directories (because they don't exist)
+        // https://cloud.google.com/storage/docs/naming#object-considerations
+        if ($this->disk->has($this->path)) {
+            $this->disk->setVisibility($this->path, 'public');
+        }
     }
 
     public function extension()


### PR DESCRIPTION

#### (optional) Issue number:
#### Summary of the change:

Google Cloud Storage (and S3, but I ran into this with GCS) don't create/store actual directories, so you can't set ACLs on them. Directories are instead inferred from object names with "/" in them.

A $this->disk->makeDirectory() call will fail, but that can be worked around with 'disable_asserts' => true in the filesystem config. A setVisibility call fails hard though, and disable_asserts doesn't help.

This fix works around that by checking to see if the directory that we just created exists. If the filesystem supports directories, the makeDirectory call will either succeed or error if the dir couldn't be created. The dir will either exist by the time we try to setVisibility on it, or we'll have already errored.
If the filesystem doesn't support directories, the makeDirectory call will error silently if disable_asserts = true in the fs config, and the dir won't exist. setVisibility would error, but we now skip doing that if the dir doesn't exist.

https://cloud.google.com/storage/docs/naming#object-considerations
https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html