### PR TITLE
Swap global string helpers for fully-qualified classes.

### DIFF
--- a/src/Traits/LfmHelpers.php
+++ b/src/Traits/LfmHelpers.php
@@ -269,7 +269,7 @@ trait LfmHelpers
      */
     private function removeFirstSlash($path)
     {
-        if (starts_with($path, $this->ds)) {
+        if (Str::startsWith($path, $this->ds)) {
             $path = substr($path, 1);
         }
 
@@ -519,7 +519,7 @@ trait LfmHelpers
     {
         $mime_type = $this->getFileType($file);
 
-        return starts_with($mime_type, 'image');
+        return Str::startsWith($mime_type, 'image');
     }
 
     /**

--- a/src/Traits/LfmHelpers.php
+++ b/src/Traits/LfmHelpers.php
@@ -2,8 +2,8 @@
 
 namespace UniSharp\LaravelFilemanager\Traits;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait LfmHelpers
@@ -152,7 +152,7 @@ trait LfmHelpers
         $thumb_folder_name = config('lfm.thumb_folder_name');
         // if user is inside thumbs folder, there is no need
         // to add thumbs substring to the end of url
-        $in_thumb_folder = str_contains($this->getFormatedWorkingDir(), $this->ds . $thumb_folder_name);
+        $in_thumb_folder = Str::contains($this->getFormatedWorkingDir(), $this->ds . $thumb_folder_name);
 
         if (! $in_thumb_folder) {
             return $thumb_folder_name . $this->ds;

--- a/src/Traits/LfmHelpers.php
+++ b/src/Traits/LfmHelpers.php
@@ -285,7 +285,7 @@ trait LfmHelpers
     private function removeLastSlash($path)
     {
         // remove last slash
-        if (ends_with($path, $this->ds)) {
+        if (Str::endsWith($path, $this->ds)) {
             $path = substr($path, 0, -1);
         }
 

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -206,8 +206,8 @@
           }
       });
       },
-      acceptedFiles: "{{ lcfirst(str_singular(request('type') ?: '')) == 'image' ? implode(',', config('lfm.valid_image_mimetypes')) : implode(',', config('lfm.valid_file_mimetypes')) }}",
-      maxFilesize: ({{ lcfirst(str_singular(request('type') ?: '')) == 'image' ? config('lfm.max_image_size') : config('lfm.max_file_size') }} / 1000)
+      acceptedFiles: "{{ lcfirst(\Illuminate\Support\Str::singular(request('type') ?: '')) == 'image' ? implode(',', config('lfm.valid_image_mimetypes')) : implode(',', config('lfm.valid_file_mimetypes')) }}",
+      maxFilesize: ({{ lcfirst(\Illuminate\Support\Str::singular(request('type') ?: '')) == 'image' ? config('lfm.max_image_size') : config('lfm.max_file_size') }} / 1000)
     }
   </script>
 </body>

--- a/src/views/list-view.blade.php
+++ b/src/views/list-view.blade.php
@@ -25,7 +25,7 @@
         @endif
 
         <a class="{{ $item->is_file ? 'file' : 'folder'}}-item clickable" data-id="{{ $item->is_file ? $item->url : $item->path }}" title="{{$item->name}}">
-          {{ str_limit($item->name, $limit = 40, $end = '...') }}
+          {{ \Illuminate\Support\Str::limit($item->name, $limit = 40, $end = '...') }}
         </a>
       </td>
       <td>{{ $item->size }}</td>
@@ -79,7 +79,7 @@
             <div class="media-heading">
               <p>
                 <a class="{{ $item->is_file ? 'file' : 'folder'}}-item clickable" data-id="{{ $item->is_file ? $item->url : $item->path }}">
-                  {{ str_limit($item->name, $limit = 20, $end = '...') }}
+                  {{ \Illuminate\Support\Str::limit($item->name, $limit = 20, $end = '...') }}
                 </a>
                 &nbsp;&nbsp;
                 {{-- <a href="javascript:rename({{ json_encode($item->name) }})">


### PR DESCRIPTION
#### (optional) Issue number: #834 
#### Summary of the change:
Laravel 6.x compat.

#903 was not complete. This swaps out all remaining `str_` calls. 