### PR TITLE
Use slug instead of preg_replace

### DIFF
--- a/src/Controllers/FolderController.php
+++ b/src/Controllers/FolderController.php
@@ -2,6 +2,8 @@
 
 namespace UniSharp\LaravelFilemanager\Controllers;
 
+use Illuminate\Support\Str;
+
 class FolderController extends LfmController
 {
     /**
@@ -42,13 +44,20 @@ class FolderController extends LfmController
         try {
             if ($folder_name === null || $folder_name == '') {
                 return $this->helper->error('folder-name');
-            } elseif ($this->lfm->setName($folder_name)->exists()) {
-                return $this->helper->error('folder-exist');
-            } elseif (config('lfm.alphanumeric_directory') && preg_match('/[^\w-]/i', $folder_name)) {
-                return $this->helper->error('folder-alnum');
-            } else {
-                $this->lfm->setName($folder_name)->createFolder();
             }
+            if ($this->lfm->setName($folder_name)->exists()) {
+                return $this->helper->error('folder-exist');
+            }
+
+            if (config('lfm.alphanumeric_directory')) {
+                if (config('lfm.convert_to_alphanumeric')) {
+                    $folder_name = Str::slug($folder_name);
+                } elseif (preg_match('/[^\w\-_]/i', $folder_name)) {
+                    return $this->helper->error('folder-alnum');
+                }
+            }
+
+            $this->lfm->setName($folder_name)->createFolder();
         } catch (\Exception $e) {
             return $e->getMessage();
         }

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -3,6 +3,7 @@
 namespace UniSharp\LaravelFilemanager;
 
 use Illuminate\Container\Container;
+use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use UniSharp\LaravelFilemanager\Events\ImageIsUploading;
@@ -276,7 +277,7 @@ class LfmPath
         if (config('lfm.rename_file') === true) {
             $new_file_name = uniqid();
         } elseif (config('lfm.alphanumeric_filename') === true) {
-            $new_file_name = preg_replace('/[^A-Za-z0-9\-\']/', '_', $new_file_name);
+            $new_file_name = Str::slug($new_file_name);
         }
 
         $extension = $file->getClientOriginalExtension();

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -98,6 +98,9 @@ return [
 
     'alphanumeric_directory'   => false,
 
+    // When creating folder or renaming folder/file, automatically convert to alphanumeric instead of error
+    'convert_to_alphanumeric'  => false,
+
     'should_validate_size'     => false,
 
     'should_validate_mime'     => false,


### PR DESCRIPTION
#### Summary of the change:
Currently, when I set `alphanumeric_filename` and upload file with accents like **Test - Žluťoučký kůň.pdf** I got file named `Test-__lu__ou________k____.pdf`. In my PR I propose to use `Str::slug()` instead of `preg_replace()`.

I also extended alphanumeric functionality with `convert_to_alphanumeric` config option. If this is set to `true`, then when renaming or creating folder user inputs some non-alphanum characters, everything is converted to alphanum with `Str::slug()` instead of poping error out.