### PR TITLE
Add helper function with Promise

### DIFF
--- a/public/js/filemanager.js
+++ b/public/js/filemanager.js
@@ -1,0 +1,22 @@
+/**
+ * Open file manager and return selected files.
+ * Promise is never resolved if window is closed.
+ *
+ * @returns Promise<array> Array of selected files with properties:
+ *      icon        string
+ *      is_file     bool
+ *      is_image    bool
+ *      name        string
+ *      thumb_url   string|null
+ *      time        int
+ *      url         string
+ */
+window.filemanager = function filemanager() {
+    var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '/filemanager';
+    var target = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'FileManager';
+    var features = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'width=900,height=600';
+    return new Promise(function (resolve) {
+        window.open(url, target, features);
+        window.SetUrl = resolve;
+    });
+};

--- a/public/js/filemanager.min.js
+++ b/public/js/filemanager.min.js
@@ -1,0 +1,1 @@
+window.filemanager=function(){var n=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"/filemanager",e=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"FileManager",i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:"width=900,height=600";return new Promise(function(o){window.open(n,e,i),window.SetUrl=o})};


### PR DESCRIPTION
Adds promise based helper function for some neat usage, i.e.
```javascript
filemanager().then(files => {
    // do stuff with files
});
```

Handy when one writes custom JS handlers.
Already optimized to cover as much browsers as possible.
Perhaps worth adding somewhere in the docs, too?