### PR TITLE
Added ability to rename file on duplicate

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -273,19 +273,37 @@ class LfmPath
         $new_file_name = $this->helper
             ->translateFromUtf8(trim(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME)));
 
+        $extension = $file->getClientOriginalExtension();
+
+
         if (config('lfm.rename_file') === true) {
             $new_file_name = uniqid();
         } elseif (config('lfm.alphanumeric_filename') === true) {
             $new_file_name = preg_replace('/[^A-Za-z0-9\-\']/', '_', $new_file_name);
         }
-
-        $extension = $file->getClientOriginalExtension();
-
         if ($extension) {
-            $new_file_name .= '.' . $extension;
+            $new_file_name_with_extention = $new_file_name . '.' . $extension;
+        }
+            if (config('lfm.rename_duplicates') === true) {
+            $counter = 1;
+            $file_name_without_extentions = $new_file_name;
+            while ($this->setName(($extension) ? $new_file_name_with_extention : $new_file_name)->exists()) {
+
+                if (config('lfm.alphanumeric_filename') === true) {
+                    $suffix = '_'.$counter;
+                } else {
+                    $suffix = " ({$counter})";
+                }
+                $new_file_name = $file_name_without_extentions.$suffix;
+
+                if ($extension) {
+                    $new_file_name_with_extention = $new_file_name . '.' . $extension;
+                }
+                $counter++;
+            }
         }
 
-        return $new_file_name;
+        return ($extension) ? $new_file_name_with_extention : $new_file_name;
     }
 
     private function saveFile($file, $new_file_name)

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -275,16 +275,17 @@ class LfmPath
 
         $extension = $file->getClientOriginalExtension();
 
-
         if (config('lfm.rename_file') === true) {
             $new_file_name = uniqid();
         } elseif (config('lfm.alphanumeric_filename') === true) {
             $new_file_name = preg_replace('/[^A-Za-z0-9\-\']/', '_', $new_file_name);
         }
+
         if ($extension) {
             $new_file_name_with_extention = $new_file_name . '.' . $extension;
         }
-            if (config('lfm.rename_duplicates') === true) {
+
+        if (config('lfm.rename_duplicates') === true) {
             $counter = 1;
             $file_name_without_extentions = $new_file_name;
             while ($this->setName(($extension) ? $new_file_name_with_extention : $new_file_name)->exists()) {

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -289,7 +289,6 @@ class LfmPath
             $counter = 1;
             $file_name_without_extentions = $new_file_name;
             while ($this->setName(($extension) ? $new_file_name_with_extention : $new_file_name)->exists()) {
-
                 if (config('lfm.alphanumeric_filename') === true) {
                     $suffix = '_'.$counter;
                 } else {

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -94,6 +94,8 @@ return [
 
     'rename_file'              => false,
 
+    'rename_duplicates'        => false,
+
     'alphanumeric_filename'    => false,
 
     'alphanumeric_directory'   => false,


### PR DESCRIPTION
Instead of overwrite or displaying an error to the user.
#### Summary of the change:
After that change if `rename_duplicates` options is enabled:

When user upload a file with a name that exists, lfm try to add suffix with incrementing number like in Windows:
![windows_like_suffix](https://user-images.githubusercontent.com/53520672/88640364-287f0c80-d0be-11ea-9b47-fcedf89571eb.png)


If `rename_duplicates` and `alphanumeric_filename` options are enabled:
When user upload a file with a name that exists, lfm try to add suffix with incrementing number forwarded by underscore:
![alfanumberic_like_suffix](https://user-images.githubusercontent.com/53520672/88640506-5401f700-d0be-11ea-8649-b95aaec9d08f.png)