### PR TITLE
Fix pathinfo problem with Persian characters

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -46,6 +46,7 @@ class Lfm
      */
     public function getNameFromPath($path)
     {
+        setlocale(LC_ALL, 'en_US.UTF-8');
         return pathinfo($path, PATHINFO_BASENAME);
     }
 

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -270,6 +270,7 @@ class LfmPath
 
     private function getNewName($file)
     {
+        setlocale(LC_ALL, 'en_US.UTF-8');
         $new_file_name = $this->helper
             ->translateFromUtf8(trim(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME)));
 

--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -66,6 +66,7 @@ class LfmStorageRepository
 
     public function extension()
     {
+        setlocale(LC_ALL, 'en_US.UTF-8');
         return pathinfo($this->path, PATHINFO_EXTENSION);
     }
 }


### PR DESCRIPTION
#### (optional) Issue number: #966
#### Summary of the change: 
Add this 
`setlocale(LC_ALL, 'en_US.UTF-8');` 
before each pathinfo() function to correct the Persian name in upload or list files.
