### PR TITLE
Fix Loading of Config

### DIFF
--- a/src/Controllers/LfmController.php
+++ b/src/Controllers/LfmController.php
@@ -83,7 +83,8 @@ class LfmController extends Controller
      */
     public function applyIniOverrides()
     {
-        $overrides = config('lfm.php_ini_overrides');
+        $overrides = config('lfm.php_ini_overrides', []);
+        
         if ($overrides && is_array($overrides) && count($overrides) === 0) {
             return;
         }

--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -51,7 +51,7 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom('config/lfm.php', 'lfm-config');
+        $this->mergeConfigFrom(__DIR__ . '/config/lfm.php', 'lfm-config');
 
         $this->app->singleton('laravel-filemanager', function () {
             return true;

--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -51,6 +51,8 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom('config/lfm.php', 'lfm-config');
+
         $this->app->singleton('laravel-filemanager', function () {
             return true;
         });


### PR DESCRIPTION
This PR addresses the following issues:
- no longer requires config to be published, and will load default config automatically.
- if config isn't published, will not fail the route check in the service provider.
- fixes `foreach` loop in LfmController so that it falls back to empty array if config doesn't return a value, thus not breaking the loop.

Fixes #790 

### Temporary workaround until this PR is merged:

1. `composer require cweagans/composer-patches`
2. Add the following to composer.json:
  ```json
    "extra": {
        "patches": {
            "unisharp/laravel-filemanager": {
                "PR #969: Fix Loading of Config": "https://patch-diff.githubusercontent.com/raw/UniSharp/laravel-filemanager/pull/969.diff"
            }
        }
    }
  ```

3. Run `composer update`