### PR TITLE
Fix 'valid_mime' issue in config file

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -48,18 +48,6 @@ return [
     'folder_categories'        => [
         'file'  => [
             'folder_name'  => 'files',
-            'startup_view' => 'grid',
-            'max_size'     => 50000, // size in KB
-            'valid_mime'   => [
-                'image/jpeg',
-                'image/pjpeg',
-                'image/png',
-                'image/gif',
-                'image/svg+xml',
-            ],
-        ],
-        'image' => [
-            'folder_name'  => 'photos',
             'startup_view' => 'list',
             'max_size'     => 50000, // size in KB
             'valid_mime'   => [
@@ -70,6 +58,18 @@ return [
                 'image/svg+xml',
                 'application/pdf',
                 'text/plain',
+            ],
+        ],
+        'image' => [
+            'folder_name'  => 'photos',
+            'startup_view' => 'grid',
+            'max_size'     => 50000, // size in KB
+            'valid_mime'   => [
+                'image/jpeg',
+                'image/pjpeg',
+                'image/png',
+                'image/gif',
+                'image/svg+xml',
             ],
         ],
     ],


### PR DESCRIPTION
'valid_mime' and 'startup_view' values for 'file' and 'image' categories is vice-versa. I swapped them and it's correct now.
