### PR TITLE
Don't set public visibility when uploading files.

### DIFF
--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -45,7 +45,7 @@ class LfmStorageRepository
         $nameint = strripos($this->path, "/");
         $nameclean = substr($this->path, $nameint + 1);
         $pathclean = substr_replace($this->path, "", $nameint);
-        $this->disk->putFileAs($pathclean, $file, $nameclean, 'public');
+        $this->disk->putFileAs($pathclean, $file, $nameclean);
     }
 
     public function url($path)


### PR DESCRIPTION
When using filesystem drives like `S3`, `GCS` or `DO Spaces`, it is recommended that the file is not set to `public` visibility. 
This should be driven by what is setup on laravel's filesystem configuration.

When a S3 bucket doesn't have public visibility, uploading a file with `public` visibility will throw the following error

```
Aws\S3\Exception\S3Exception' with message 'Error executing "PutObject" on {S3 URL} ; AWS HTTP error: Client error: `PUT {S3 URL}` resulted in a `403 Forbidden`
```
