### PR TITLE
Added LfmItem property selection via config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /docs/Gemfile.lock
 /docs/_site
 .DS_Store
+/.idea

--- a/src/LfmItem.php
+++ b/src/LfmItem.php
@@ -12,7 +12,7 @@ class LfmItem
     private $isDirectory;
     private $mimeType = null;
 
-    private $columns = ['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url'];
+    private $columns = [];
     public $attributes = [];
 
     public function __construct(LfmPath $lfm, Lfm $helper, $isDirectory = false)
@@ -20,6 +20,7 @@ class LfmItem
         $this->lfm = $lfm->thumb(false);
         $this->helper = $helper;
         $this->isDirectory = $isDirectory;
+        $this->columns = $helper->config('item_columns')??['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url'];
     }
 
     public function __get($var_name)

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -109,6 +109,9 @@ return [
     // setting it to false show `error-file-exist` error and stop upload
     'over_write_on_duplicate'  => false,
 
+    // Item Columns
+    'item_columns' => ['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url'],
+
     /*
     |--------------------------------------------------------------------------
     | Thumbnail

--- a/tests/LfmItemTest.php
+++ b/tests/LfmItemTest.php
@@ -19,6 +19,7 @@ class LfmItemTest extends TestCase
 
         $this->lfm_path = m::mock(LfmPath::class);
         $this->lfm_path->shouldReceive('thumb')->andReturn($this->lfm_path);
+        $this->lfm->shouldReceive('config')->with('item_columns')->andReturn(['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url']);
     }
 
     public function tearDown()
@@ -30,7 +31,7 @@ class LfmItemTest extends TestCase
 
     public function testMagicGet()
     {
-        $this->lfm_item = new LfmItem($this->lfm_path, m::mock(Lfm::class));
+        $this->lfm_item = new LfmItem($this->lfm_path, $this->lfm);
 
         $this->lfm_item->attributes['foo'] = 'bar';
 

--- a/tests/LfmPathTest.php
+++ b/tests/LfmPathTest.php
@@ -126,6 +126,7 @@ class LfmPathTest extends TestCase
         $helper->shouldReceive('getThumbFolderName')->andReturn('thumbs');
         $helper->shouldReceive('isRunningOnWindows')->andReturn(false);
         $helper->shouldReceive('ds')->andReturn('/');
+        $helper->shouldReceive('config')->with('item_columns')->andReturn(['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url']);
 
         $path = new LfmPath($helper);
 
@@ -145,6 +146,7 @@ class LfmPathTest extends TestCase
         $helper->shouldReceive('getNameFromPath')->andReturn('bar');
         $helper->shouldReceive('isRunningOnWindows')->andReturn(false);
         $helper->shouldReceive('ds')->andReturn('/');
+        $helper->shouldReceive('config')->with('item_columns')->andReturn(['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url']);
 
         $path = new LfmPath($helper);
 
@@ -156,6 +158,7 @@ class LfmPathTest extends TestCase
         $helper = m::mock(Lfm::class);
         $helper->shouldReceive('getNameFromPath')->andReturn('bar');
         $helper->shouldReceive('isRunningOnWindows')->andReturn(false);
+        $helper->shouldReceive('config')->with('item_columns')->andReturn(['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url']);
 
         $path = new LfmPath($helper);
 


### PR DESCRIPTION
#### (optional) Issue number:
#### Summary of the change:
Added a custom config item_columns for LfmItem columns property. This changes will be very helpful for those people who want to get file path (import excel) selected by UniSharp/laravel-filemanager.