### PR TITLE
Package routes update

### DIFF
--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -38,7 +38,7 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider
         ], 'lfm_handler');
 
         if (config('lfm.use_package_routes')) {
-            Route::group(['prefix' => 'filemanager', 'middleware' => ['web', 'auth']], function () {
+            Route::group(['prefix' => config('lfm.url_prefix') ?: 'filemanager', 'middleware' => config('lfm.middlewares') ?: ['web', 'auth']], function () {
                 \UniSharp\LaravelFilemanager\Lfm::routes();
             });
         }

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -17,6 +17,12 @@ return [
 
     'use_package_routes'       => true,
 
+    //Middlewares to be applied to default routes when use_package_routes is true
+    'middlewares'              => ['web','auth'],
+
+    //The url prefix to this package.
+    'url_prefix'               => 'filemanager',
+
     /*
     |--------------------------------------------------------------------------
     | Shared folder / Private folder

--- a/src/views/demo.blade.php
+++ b/src/views/demo.blade.php
@@ -52,7 +52,7 @@
     <div class="row">
       <div class="col-md-12">
         <h2 class="mt-4">Embed file manager</h2>
-        <iframe src="/filemanager" style="width: 100%; height: 500px; overflow: hidden; border: none;"></iframe>
+        <iframe src="/{{config('lfm.url_prefix') ?: 'filemanager'}}" style="width: 100%; height: 500px; overflow: hidden; border: none;"></iframe>
       </div>
     </div>
   </div>
@@ -61,7 +61,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"></script>
   <script>
-   var route_prefix = "/filemanager";
+   var route_prefix = "/{{config('lfm.url_prefix') ?: 'filemanager'}}";
   </script>
 
   <!-- CKEditor init -->
@@ -186,7 +186,7 @@
           tooltip: 'Insert image with filemanager',
           click: function() {
 
-            lfm({type: 'image', prefix: '/filemanager'}, function(lfmItems, path) {
+            lfm({type: 'image', prefix: route_prefix}, function(lfmItems, path) {
               lfmItems.forEach(function (lfmItem) {
                 context.invoke('insertImage', lfmItem.url);
               });


### PR DESCRIPTION
#### Summary of the change:
#### Issue 1:
if (config('lfm.use_package_routes')) is true then a route with prefix `'filemanger'` and middleware `['web','auth’]` is applied
in this case if the user doesn’t have `web` middleware he will get `Target class [web] does not exist.` error.
#### The suggested solution:
this can be fixed by adding `middlewares` array in config, if present it will take the values or fallback to `['web','auth’]`
making the prefix variable is also preferable by adding `url_prefix`, so if `url_prefix` is present in config the route will take that value, else it will fallback to `filemanager`
#### Issue 2:
The demo is using `/filemanger` route, but in case the user creates custom route with prefix different than `/filemanger` (and sets the `lfm.use_package_routes` to false) the demo will no longer work because it will not find any route named `/filemanger`
#### The suggested solution:
This can be fixed by initializing the variable `route_prefix` in the demo view with the `url_prefix` value from config if present, then fallback to `/filemanager` if no value is present
#### Recap:
Optional `url_prefix` and `middlewares` are added to config file, so in case of `use_package_routes` is true, the route generated will try to get `prefix` value and `middleware` array from config file before falling back to static values.
Also if the user creates a route with a custom prefix, he can set that prefix in config, so it will be used in the demo without failing if `use_package_routes` is false.