### PR TITLE
add Authorization token to Dropzone.options.uploadForm only if it is present in the url

### DIFF
--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -281,11 +281,15 @@
           }
         });
       },
-      headers: {
-        'Authorization': 'Bearer ' + getUrlParam('token')
-      },
       acceptedFiles: "{{ implode(',', $helper->availableMimeTypes()) }}",
       maxFilesize: ({{ $helper->maxUploadSize() }} / 1000)
+    }
+
+    var token = getUrlParam('token');
+    if (token !== null) {
+      Dropzone.options.uploadForm.headers = {
+        'Authorization': 'Bearer ' + token
+      };
     }
   </script>
 </body>


### PR DESCRIPTION
Hello.

#### Summary of the change:
This PR add **Authorization** header to Dropzone config just if they present in url.

### My problem
When my site is blocked by authorization (special), I cannot upload files, because dropzone setting overrides the Authorization header.

### Same PR
https://github.com/UniSharp/laravel-filemanager/pull/660

Thanks for this nice package.