### PR TITLE
Dropzone uploadMultiple: true error fix

### DIFF
--- a/src/Controllers/UploadController.php
+++ b/src/Controllers/UploadController.php
@@ -2,6 +2,7 @@
 
 namespace UniSharp\LaravelFilemanager\Controllers;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use UniSharp\LaravelFilemanager\Events\ImageIsUploading;
 use UniSharp\LaravelFilemanager\Events\ImageWasUploaded;
@@ -25,7 +26,7 @@ class UploadController extends LfmController
      */
     public function upload()
     {
-        $uploaded_files = request()->file('upload');
+        $uploaded_files = Arr::flatten(request()->file('upload'));
         $error_bag = [];
         $new_filename = null;
 


### PR DESCRIPTION
When you set uploadMultiple : true in dropzone 5.7.2 request create multidimensional input of the upload like 
upload[][0]: (binary)
upload[][1]: (binary)
upload[][2]: (binary)

When you send this request it is trying to validate this array value in UniSharp\LaravelFilemanager::uploadValidator()  but it is not a instance of UploadedFile it is instance of array. So with flatting this array we convert its dimension to 
upload[0]: (binary)
upload[1]: (binary)
upload[2]: (binary)

#### (optional) Issue number:
#### Summary of the change:
