### PR TITLE
Dropzone uploadMultiple: true error fix

### DIFF
--- a/src/Controllers/UploadController.php
+++ b/src/Controllers/UploadController.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Log;
 use UniSharp\LaravelFilemanager\Events\ImageIsUploading;
 use UniSharp\LaravelFilemanager\Events\ImageWasUploaded;
 use UniSharp\LaravelFilemanager\Lfm;
+use Illuminate\Support\Arr;
 
 class UploadController extends LfmController
 {
@@ -29,7 +30,7 @@ class UploadController extends LfmController
         $error_bag = [];
         $new_filename = null;
 
-        foreach (is_array($uploaded_files) ? $uploaded_files : [$uploaded_files] as $file) {
+        foreach (is_array($uploaded_files) ? Arr::flatten($uploaded_files) : [$uploaded_files] as $file) {
             try {
                 $new_filename = $this->lfm->upload($file);
             } catch (\Exception $e) {


### PR DESCRIPTION
When you set Dropzone.options.uploadForm.uploadMultiple : true in config of an instance of dropzone 5.7.2 the request is created by dropzone creates multidimensional input of the upload like below;
upload[][0]: (binary)
upload[][1]: (binary)
upload[][2]: (binary)

When you send this request it is trying to validate this array values which is already array in UniSharp\LaravelFilemanager::uploadValidator() but it is not a instance of UploadedFile it is instance of array. So with flatting this array we convert request array to a single dimension array like below;
upload[0]: (binary)
upload[1]: (binary)
upload[2]: (binary)

#### (optional) Issue number:
#### Summary of the change:
