### PR TITLE
Allow config to set the files folder to the root

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -66,7 +66,10 @@ class LfmPath
             return $this->translateToLfmPath($this->normalizeWorkingDir());
         } elseif ($type == 'url') {
             // storage: files/{user_slug}
-            return $this->helper->getCategoryName() . $this->path('working_dir');
+            // storage without folder: {user_slug}
+            return $this->helper->getCategoryName() === '.'
+                ? ltrim($this->path('working_dir'), '/')
+                : $this->helper->getCategoryName() . $this->path('working_dir');
         } elseif ($type == 'storage') {
             // storage: files/{user_slug}
             // storage on windows: files\{user_slug}


### PR DESCRIPTION
The LfmPath storage "url" path would return the "working_dir" path if the folder name was an empty string.

This update will ensure the "url" path will return the "working_dir" with the root slash removed if the folder_name is set to ".".

The reason for this PR is to allow new installations of LFM to work on preexisting folder structures with little configuration.