### PR TITLE
enable allow_private_folder & allow_shared_folder to be overridden for each ‘type’

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -195,6 +195,12 @@ class Lfm
      */
     public function allowMultiUser()
     {
+        $type_key = $this->currentLfmType();
+
+        if ($this->config->has('lfm.folder_categories.' . $type_key . '.allow_private_folder')) {
+            return $this->config->get('lfm.folder_categories.' . $type_key . '.allow_private_folder') === true;
+        }
+
         return $this->config->get('lfm.allow_private_folder') === true;
     }
 
@@ -208,6 +214,12 @@ class Lfm
     {
         if (! $this->allowMultiUser()) {
             return true;
+        }
+
+        $type_key = $this->currentLfmType();
+
+        if ($this->config->has('lfm.folder_categories.' . $type_key . '.allow_shared_folder')) {
+            return $this->config->get('lfm.folder_categories.' . $type_key . '.allow_shared_folder') === true;
         }
 
         return $this->config->get('lfm.allow_shared_folder') === true;


### PR DESCRIPTION
#### Summary of the change:

Should be pretty self-explanatory.. either of allow_private_folder or allow_shared_folder booleans can be configured (over-ridden) within each 'folder_categories' array within lfm.php config file, and if specified there, these settings replace the 'global' setting.

Enables private/shared folders to be configured in a more fine-grained way for different 'type's.