### PR TITLE
a fix for issue #868

### DIFF
--- a/src/Controllers/DeleteController.php
+++ b/src/Controllers/DeleteController.php
@@ -50,11 +50,7 @@ class DeleteController extends LfmController
             }
 
             if ($this->lfm->setName($name_to_delete)->isDirectory()) {
-                if (! $this->lfm->setName($name_to_delete)->directoryIsEmpty()) {
-                    array_push($errors, parent::error('delete-folder'));
-                    continue;
-                }
-
+                
                 $this->lfm->setName($name_to_delete)->delete();
 
                 event(new FolderWasDeleted($file_path));


### PR DESCRIPTION
#### (optional) Issue number:  #868
#### Summary of the change: allows the deletion of a not-empty directory without throwing 500 error
