### PR TITLE
Fixed tinymce5 changing image issue

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -760,7 +760,7 @@ function usingTinymce3() {
 }
 
 function usingTinymce4AndColorbox() {
-  return !!getUrlParam('field_name');
+  return !!getUrlParam('field_name') && getUrlParam('editor') != 'tinymce5';
 }
 
 function usingTinymce5(){


### PR DESCRIPTION
In TinyMCE 5, when trying to select new image to replace exist one the function usingTinymce4AndColorbox() returns TRUE (False Positive).
The bug is preventing from changing the existing image.
I fixed it with extra check to insure usingTinymce4AndColorbox() is returning FALSE when TinyMCE 5 is active.
