### PR TITLE
File extension validation fix

### DIFF
--- a/src/Controllers/UploadController.php
+++ b/src/Controllers/UploadController.php
@@ -49,7 +49,7 @@ class UploadController extends LfmController
         } else { // upload via ckeditor5 expects json responses
             if (is_null($new_filename)) {
                 $response = [
-                    'error' => [ 'message' =>  $error_bag[0] ]
+                    'error' => ['message' =>  $error_bag[0]]
                 ];
             } else {
                 $url = $this->lfm->setName($new_filename)->url();

--- a/src/Exceptions/InvalidExtensionException.php
+++ b/src/Exceptions/InvalidExtensionException.php
@@ -4,8 +4,8 @@ namespace UniSharp\LaravelFilemanager\Exceptions;
 
 class InvalidExtensionException extends \Exception
 {
-    public function __construct($ext)
+    public function __construct()
     {
-        $this->message = trans('laravel-filemanager::lfm.error-extension') . $ext;
+        $this->message = trans('laravel-filemanager::lfm.error-invalid');
     }
 }

--- a/src/Exceptions/InvalidExtensionException.php
+++ b/src/Exceptions/InvalidExtensionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace UniSharp\LaravelFilemanager\Exceptions;
+
+class InvalidExtensionException extends \Exception
+{
+    public function __construct($ext)
+    {
+        $this->message = trans('laravel-filemanager::lfm.error-extension') . $ext;
+    }
+}

--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -162,7 +162,7 @@ class Lfm
     {
         return $this->config->get('lfm.folder_categories.' . $this->currentLfmType() . '.valid_mime');
     }
-    
+
     public function shouldCreateCategoryThumb()
     {
         return $this->config->get('lfm.folder_categories.' . $this->currentLfmType() . '.thumb');
@@ -212,7 +212,7 @@ class Lfm
      */
     public function allowShareFolder()
     {
-        if (! $this->allowMultiUser()) {
+        if (!$this->allowMultiUser()) {
             return true;
         }
 
@@ -284,7 +284,7 @@ class Lfm
      */
     public static function routes()
     {
-        $middleware = [ CreateDefaultFolder::class, MultiUser::class ];
+        $middleware = [CreateDefaultFolder::class, MultiUser::class];
         $as = 'unisharp.lfm.';
         $namespace = '\\UniSharp\\LaravelFilemanager\\Controllers\\';
 

--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -162,7 +162,7 @@ class Lfm
     {
         return $this->config->get('lfm.folder_categories.' . $this->currentLfmType() . '.valid_mime');
     }
-
+    
     public function shouldCreateCategoryThumb()
     {
         return $this->config->get('lfm.folder_categories.' . $this->currentLfmType() . '.thumb');
@@ -212,7 +212,7 @@ class Lfm
      */
     public function allowShareFolder()
     {
-        if (!$this->allowMultiUser()) {
+        if (! $this->allowMultiUser()) {
             return true;
         }
 
@@ -284,7 +284,7 @@ class Lfm
      */
     public static function routes()
     {
-        $middleware = [CreateDefaultFolder::class, MultiUser::class];
+        $middleware = [ CreateDefaultFolder::class, MultiUser::class ];
         $as = 'unisharp.lfm.';
         $namespace = '\\UniSharp\\LaravelFilemanager\\Controllers\\';
 

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -263,6 +263,8 @@ class LfmPath
             $validator->sizeIsLowerThanConfiguredMaximum($this->helper->maxUploadSize());
         }
 
+        $validator->hasAllowedExtension(config('lfm.allowed_extensions', ['jpg', 'png', 'gif', 'jpeg']));
+
         return true;
     }
 
@@ -289,11 +291,11 @@ class LfmPath
             $file_name_without_extentions = $new_file_name;
             while ($this->setName(($extension) ? $new_file_name_with_extention : $new_file_name)->exists()) {
                 if (config('lfm.alphanumeric_filename') === true) {
-                    $suffix = '_'.$counter;
+                    $suffix = '_' . $counter;
                 } else {
                     $suffix = " ({$counter})";
                 }
-                $new_file_name = $file_name_without_extentions.$suffix;
+                $new_file_name = $file_name_without_extentions . $suffix;
 
                 if ($extension) {
                     $new_file_name_with_extention = $new_file_name . '.' . $extension;

--- a/src/LfmUploadValidator.php
+++ b/src/LfmUploadValidator.php
@@ -78,7 +78,7 @@ class LfmUploadValidator
         $extension = $this->file->getClientOriginalExtension();
 
         if (!in_array($extension, $allowed_extensions)) {
-            throw new InvalidExtensionException($extension);
+            throw new InvalidExtensionException();
         }
 
         return $this;

--- a/src/LfmUploadValidator.php
+++ b/src/LfmUploadValidator.php
@@ -9,6 +9,7 @@ use UniSharp\LaravelFilemanager\Exceptions\ExcutableFileException;
 use UniSharp\LaravelFilemanager\Exceptions\FileFailedToUploadException;
 use UniSharp\LaravelFilemanager\Exceptions\FileSizeExceedConfigurationMaximumException;
 use UniSharp\LaravelFilemanager\Exceptions\FileSizeExceedIniMaximumException;
+use UniSharp\LaravelFilemanager\Exceptions\InvalidExtensionException;
 use UniSharp\LaravelFilemanager\Exceptions\InvalidMimeTypeException;
 use UniSharp\LaravelFilemanager\LfmPath;
 
@@ -67,6 +68,17 @@ class LfmUploadValidator
 
         if (in_array($mimetype, $excutable_mimetypes)) {
             throw new ExcutableFileException();
+        }
+
+        return $this;
+    }
+
+    function hasAllowedExtension($allowed_extensions)
+    {
+        $extension = $this->file->getClientOriginalExtension();
+
+        if (!in_array($extension, $allowed_extensions)) {
+            throw new InvalidExtensionException($extension);
         }
 
         return $this;

--- a/src/LfmUploadValidator.php
+++ b/src/LfmUploadValidator.php
@@ -73,7 +73,7 @@ class LfmUploadValidator
         return $this;
     }
 
-    function hasAllowedExtension($allowed_extensions)
+    public function hasAllowedExtension($allowed_extensions)
     {
         $extension = $this->file->getClientOriginalExtension();
 

--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -116,6 +116,9 @@ return [
     // mimetypes of executables to prevent from uploading
     'disallowed_mimetypes' => ['text/x-php', 'text/html', 'text/plain'],
 
+    // allowed file extensions
+    'allowed_extensions' => ['jpg', 'png', 'gif'],
+
     // Item Columns
     'item_columns' => ['name', 'url', 'time', 'icon', 'is_file', 'is_image', 'thumb_url'],
 


### PR DESCRIPTION
#### (optional) Issue number:
#### Summary of the change:
Added validation + tests to prevent uploading a php file disguised as an image by checking the file extension, rather than relying solely on the mime type check. 
Added an `allowed_types` option in the config with jpg, gif and png as default - you may want to add more as default