### PR TITLE
Fix duplicate 'img' tag in standalone button image preview

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -197,7 +197,7 @@ If you are going to use filemanager independently, meaning set the value of an i
       </span>
       <input id="thumbnail" class="form-control" type="text" name="filepath">
     </div>
-    <img id="holder" style="margin-top:15px;max-height:100px;">
+    <div id="holder" style="margin-top:15px;max-height:100px;"></div>
     ```
 1. Import lfm.js(run `php artisan vendor:publish` if you need).
 


### PR DESCRIPTION
#### (optional) Issue number:
#### Summary of the change:
- Replaced  `img` tag with `div`.  The issue causing a missing image preview by addressing the duplication of the 'img' tag in the code. Previously, the use of <img> resulted in the generation of <img><img /> </img>, leading to the absence of a preview.

![image](https://github.com/UniSharp/laravel-filemanager/assets/44586913/f92185de-80ec-442d-b0e3-8bf1ac3cb130)

