### PR TITLE
Feat: Add option to store original image before resizing

### DIFF
--- a/src/Controllers/ResizeController.php
+++ b/src/Controllers/ResizeController.php
@@ -52,14 +52,27 @@ class ResizeController extends LfmController
             ->with('ratio', $ratio);
     }
 
-    public function performResize()
+    public function performResize($overWrite = true)
     {
+        $image_name = request('img');
         $image_path = $this->lfm->setName(request('img'))->path('absolute');
+        $resize_path = $image_path;
+
+        if (! $overWrite) {
+            $fileParts = explode('.', $image_name);
+            $fileParts[count($fileParts) - 2] = $fileParts[count($fileParts) - 2] . '_resized_' . time();
+            $resize_path = $this->lfm->setName(implode('.', $fileParts))->path('absolute');
+        }
 
         event(new ImageIsResizing($image_path));
-        Image::make($image_path)->resize(request('dataWidth'), request('dataHeight'))->save();
+        Image::make($image_path)->resize(request('dataWidth'), request('dataHeight'))->save($resize_path);
         event(new ImageWasResized($image_path));
 
         return parent::$success_response;
+    }
+
+    public function performResizeNew()
+    {
+        $this->performResize(false);
     }
 }

--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -364,7 +364,10 @@ class Lfm
                 'uses' => 'ResizeController@performResize',
                 'as' => 'performResize',
             ]);
-
+            Route::get('/doresizenew', [
+                'uses' => 'ResizeController@performResizeNew',
+                'as' => 'performResizeNew',
+            ]);
             // download
             Route::get('/download', [
                 'uses' => 'DownloadController@getDownload',

--- a/src/lang/en/lfm.php
+++ b/src/lang/en/lfm.php
@@ -67,6 +67,7 @@ return [
     'btn-cancel'        => 'Cancel',
     'btn-confirm'       => 'Confirm',
     'btn-resize'        => 'Resize',
+    'btn-resize-copy'   => 'Copy & Resize',
     'btn-open'          => 'Open Folder',
 
     'resize-ratio'      => 'Ratio:',

--- a/src/views/resize.blade.php
+++ b/src/views/resize.blade.php
@@ -59,6 +59,7 @@
       </table>
       <div class="d-flex mb-3">
         <button class="btn btn-secondary w-50 mr-1" onclick="loadItems()">{{ trans('laravel-filemanager::lfm.btn-cancel') }}</button>
+        <button class="btn btn-warning w-50 mr-1" onclick="doResizeNew()">{{ trans('laravel-filemanager::lfm.btn-resize-copy') }}</button>
         <button class="btn btn-primary w-50" onclick="doResize()">{{ trans('laravel-filemanager::lfm.btn-resize') }}</button>
       </div>
 
@@ -115,6 +116,14 @@
 
   function doResize() {
     performLfmRequest('doresize', {
+      img: $("#img").val(),
+      dataHeight: $("#height").val(),
+      dataWidth: $("#width").val()
+    }).done(loadItems);
+  }
+
+  function doResizeNew() {
+    performLfmRequest('doresizenew', {
       img: $("#img").val(),
       dataHeight: $("#height").val(),
       dataWidth: $("#width").val()


### PR DESCRIPTION
Added a 'Copy & Resize' button on the resize window which will keep the original image & create a new image with new size.

#### (optional) Issue number:
#### Summary of the change:
