### PR TITLE
feat: minor chg to new_file_name in LfmPath

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -277,13 +277,13 @@ class LfmPath
         $extension = $file->getClientOriginalExtension();
 
         if (config('lfm.rename_file') === true) {
-            $new_file_name = uniqid();
+            $new_file_name = uniqid() . '_img';
         } elseif (config('lfm.alphanumeric_filename') === true) {
             $new_file_name = preg_replace('/[^A-Za-z0-9\-\']/', '_', $new_file_name);
         }
 
         if ($extension) {
-            $new_file_name_with_extention = $new_file_name . '.' . $extension;
+            $new_file_name_with_extention = $new_file_name . '_img.' . $extension;
         }
 
         if (config('lfm.rename_duplicates') === true) {


### PR DESCRIPTION
#### Summary of the change:
new_file_name changed because
images in screens will stay on screen for default 7secs
numbers before the .extension will chg default e.g.
1234_12.jpeg will stay on screen for 12secs
1234.jpeg will stay on screen for 1234secs