### PR TITLE
fix: replace Lfm.php, change method translateFromUtf8

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -233,10 +233,27 @@ class Lfm
      */
     public function translateFromUtf8($input)
     {
+        // Disabled
         if ($this->isRunningOnWindows()) {
             $input = iconv('UTF-8', mb_detect_encoding($input), $input);
         }
 
+        // Replace with this
+        if ($this->isRunningOnWindows()) {
+            // $input = iconv('UTF-8', mb_detect_encoding($input), $input);
+
+            if (is_array($input)) {
+                foreach ($input as $k => $i) {
+                    $rInput[] = iconv('UTF-8', mb_detect_encoding($i), $i);
+                }
+            } else {
+                $rInput = $input;
+            }
+        } else {
+            $rInput = $input;
+        }
+
+        return $rInput;
         return $input;
     }
 


### PR DESCRIPTION
#### Summary of the change:
Fix error in windows os for feature File Moving
I replace method `translateFromUtf8($input)` from 
```php
 public function translateFromUtf8($input)
    {
        if ($this->isRunningOnWindows()) {
            $input = iconv('UTF-8', mb_detect_encoding($input), $input);
        }

        return $input;
  }
```
To
```php
    public function translateFromUtf8($input)
    {
        if ($this->isRunningOnWindows()) {
            if (is_array($input)) {
                foreach ($input as $k => $i) {
                    $rInput[] = iconv('UTF-8', mb_detect_encoding($i), $i);
                }
            } else {
                $rInput = $input;
            }
        } else {
            $rInput = $input;
        }

        return $rInput;
    }
```

I hove this fix cant be merge, i get error message in my server, thanks
