### PR TITLE
feat: add Support for BunnyCDN, bunny doesn't support lastModified on directory, so return null when bunny detected.

### DIFF
--- a/src/LfmItem.php
+++ b/src/LfmItem.php
@@ -111,7 +111,7 @@ class LfmItem
     public function time()
     {
         if (function_exists('config')) {
-            $disk = config('disk');
+            $disk = $this->helper->config('disk');
             $driver = $disk ? config("filesystems.disks.$disk.driver") : null;
             if (($driver == 'bunny' || $driver == 'bunnycdn') && $this->isDirectory()) {
                 return null;

--- a/src/LfmItem.php
+++ b/src/LfmItem.php
@@ -110,6 +110,13 @@ class LfmItem
 
     public function time()
     {
+        if (function_exists('config')) {
+            $disk = config('disk');
+            $driver = $disk ? config("filesystems.disks.$disk.driver") : null;
+            if (($driver == 'bunny' || $driver == 'bunnycdn') && $this->isDirectory()) {
+                return null;
+            }
+        }
         return $this->lfm->lastModified();
     }
 


### PR DESCRIPTION
Currently, When I open laravel filemanager window then Flysystem for BunnyCDN throw exception because this package is trying to read lastModified on directory.

#### (optional) Issue number:
#### Summary of the change:
