### PR TITLE
Update Lfm class constructor for PHP 8.3 to explicitly declare nullab…

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -17,7 +17,7 @@ class Lfm
     protected $config;
     protected $request;
 
-    public function __construct(Config $config = null, Request $request = null)
+    public function __construct(?Config $config = null, ?Request $request = null)
     {
         $this->config = $config;
         $this->request = $request;


### PR DESCRIPTION
…le parameters, resolving the deprecation warning for assigning nullable values.

#### (optional) Issue number:
#### Summary of the change:
