### PR TITLE
force dependency injection in LfmPath constructor by removing null de…

### DIFF
--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -20,7 +20,7 @@ class LfmPath
 
     private $helper;
 
-    public function __construct(Lfm $lfm = null)
+    public function __construct(Lfm $lfm)
     {
         $this->helper = $lfm;
     }


### PR DESCRIPTION
Causing "Call to a member function getStorage() on null" error since upgrading to v2.10 and Laravel 12.

#### Issue number: 1256
#### Summary of the change: See https://github.com/UniSharp/laravel-filemanager/issues/1256

@streamtw Would be great if this can get resolved soon 🤞 