### PR TITLE
Update integration.md

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -5,7 +5,7 @@ Check `vendor/unisharp/laravel-filemanager/src/views/demo.blade.php`, which alre
 ### Option 1: CKEditor
 
 ```html
-<textarea id="my-editor" name="content" class="form-control">{!! old('content', 'test editor content') !!}</textarea>
+<textarea id="my-editor-1" name="content" class="form-control my-editor">{!! old('content', 'test editor content') !!}</textarea>
 <script src="//cdn.ckeditor.com/4.6.2/standard/ckeditor.js"></script>
 <script>
   var options = {
@@ -21,7 +21,7 @@ Check `vendor/unisharp/laravel-filemanager/src/views/demo.blade.php`, which alre
 
   ```html
   <script>
-  CKEDITOR.replace('my-editor', options);
+  CKEDITOR.replace('my-editor-1', options);
   </script>
   ```
 


### PR DESCRIPTION
Correct the CKEditor integration documentation

#### Summary of the change:
- The _JQuery_ selector was probably wrong as the dot is for selecting a class, and this `class` was missing and set on
  the `id` instead.
- To help people understand, I propose to modify the `id` to show that it has to be unique if you use this way of
  setting up the editor. Personally, I prefer the `class` version, which will handle multiple editors in the page.
