### PR TITLE
Fix `Lfm::translateFromUtf8()` to handle an array of strings and not only a string.

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -226,15 +226,21 @@ class Lfm
     }
 
     /**
-     * Translate file name to make it compatible on Windows.
+     * Translate file or directory name(s) to be compatible on Windows.
      *
-     * @param  string  $input  Any string.
-     * @return string
+     * @param  string|array  $input  Any string or array of strings.
+     * @return string|array
      */
     public function translateFromUtf8($input)
     {
         if ($this->isRunningOnWindows()) {
-            $input = iconv('UTF-8', mb_detect_encoding($input), $input);
+            if (is_array($input)) {
+                foreach ($input as &$item) {
+                    $item = iconv('UTF-8', mb_detect_encoding($item), $item);
+                }
+            } else {
+                $input = iconv('UTF-8', mb_detect_encoding($input), $input);
+            }
         }
 
         return $input;


### PR DESCRIPTION
To solve a crash (error 500) on _Windows_ env, when doing a **move** operation.

#### (optional) Issue number: #739
#### Summary of the change: Make `translateFromUtf8()` handle arrays of strings and not only a string.

Notice that it is a similar proposition of the pull requests:

- pull request #1234, which didn't update the function header and also could potentially lose the
  array keys as it is not modifying the original array but creating a new one without re-using the original keys.

- pull request #1014, which also doesn't correct the function header and creates a new array for nothing, also
  losing the original array keys.