### PR TITLE
fix: explicitly declare nullable types in constructor for PHP 8.1+

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -17,7 +17,7 @@ class Lfm
     protected $config;
     protected $request;
 
-    public function __construct(Config $config = null, Request $request = null)
+    public function __construct(?Config $config = null, ?Request $request = null)
     {
         $this->config = $config;
         $this->request = $request;


### PR DESCRIPTION
#### (optional) Issue number:
#### Summary of the change:
