### PR TITLE
patch code for php 8.4

### DIFF
--- a/src/Lfm.php
+++ b/src/Lfm.php
@@ -17,7 +17,7 @@ class Lfm
     protected $config;
     protected $request;
 
-    public function __construct(Config $config = null, Request $request = null)
+    public function __construct(?Config $config = null, ?Request $request = null)
     {
         $this->config = $config;
         $this->request = $request;


### PR DESCRIPTION
#### Summary of the change:

This pull request updates the module to be fully compatible with PHP 8.4. It resolves deprecation warnings by adjusting the syntax for nullable typed parameters to align with the new PHP 8.4 syntax. This change ensures the module functions correctly without errors in the updated environment.

Reviewers, please pull these changes and test them in a PHP 8.4 environment to confirm the fix. If you have any questions or need more info, let me know.