### PR TITLE
Fix the prefix error in the configuration

### DIFF
--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -60,7 +60,7 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/lfm.php', 'lfm-config');
+        $this->mergeConfigFrom(__DIR__.'/../config/lfm.php', 'lfm');
 
         $this->app->singleton('laravel-filemanager', function () {
             return true;


### PR DESCRIPTION
@streamtw The prefix "lfm-config" is not used in the source code. It seems there was a mistake in the code commit.
If a CDN is used, the thumbnails and image links are incorrect and cannot be displayed.