### PR TITLE
feat: nullable temporary_url_duration for permanent public urls on S3

### DIFF
--- a/src/Controllers/DownloadController.php
+++ b/src/Controllers/DownloadController.php
@@ -18,7 +18,7 @@ class DownloadController extends LfmController
         $disk = Storage::disk($this->helper->config('disk'));
         $config = $disk->getConfig();
 
-        if (key_exists('driver', $config) && $config['driver'] == 's3') {
+        if (key_exists('driver', $config) && $config['driver'] == 's3' && !is_null($this->helper->config('temporary_url_duration'))) {
             $duration = $this->helper->config('temporary_url_duration');
             return response()->streamDownload(function () {
                 echo file_get_contents($disk->temporaryUrl($file->path('storage'), now()->addMinutes($duration)));

--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -45,7 +45,7 @@ class LfmStorageRepository
     {
         $config = $this->disk->getConfig();
 
-        if (key_exists('driver', $config) && $config['driver'] == 's3') {
+        if (key_exists('driver', $config) && $config['driver'] == 's3' && !is_null($this->helper->config('temporary_url_duration'))) {
             $duration = $this->helper->config('temporary_url_duration');
             return $this->disk->temporaryUrl($path, now()->addMinutes($duration));
         } else {


### PR DESCRIPTION
#### (optional) Issue number:
N/A

#### Summary of the change:
This PR allows users to set `temporary_url_duration` to `null` to enable permanent URL generation for S3. 

Currently, if the user has specified an S3 filesystem, they _must_ use temporary URLs. However, there are cases where a user may not want this. For example, when using LFM with [Nova TInyMCE](https://novapackages.com/packages/emilianotisato/nova-tinymce) I have a use-case where the image URLs will be saved into content pages' text blocks. The requirement of generating a temporary URL doesn't really make sense in this context, so enabling a permanent URL to be saved into the database is the solution.

Thanks!