### PR TITLE
Support AWS S3 “Bucket owner enforced” (ACL-disabled) buckets

### DIFF
--- a/config/lfm.php
+++ b/config/lfm.php
@@ -104,6 +104,8 @@ return [
 
     'temporary_url_duration'   => 30,
 
+    's3_acls_disabled'         => false,
+
     'rename_file'              => false,
 
     'rename_duplicates'        => false,

--- a/docs/config.md
+++ b/docs/config.md
@@ -123,6 +123,20 @@ Detail options are explained here:
 
 Disk name of Laravel File System. All files are placed in here. Choose one of the `disks` section in `config/filesystems.php`.
 
+### temporary\_url\_duration
+
+* type: `int`
+* default: `30`
+
+Duration of AWS S3 temporary urls, in minutes.
+
+### s3\_acls\_disabled
+
+* type: `boolean`
+* default: `false`
+
+Enable to support AWS S3 “Bucket owner enforced” (ACL-disabled) buckets.
+
 ### rename\_file
 
 * type: `boolean`

--- a/src/Controllers/DownloadController.php
+++ b/src/Controllers/DownloadController.php
@@ -20,8 +20,12 @@ class DownloadController extends LfmController
 
         if (key_exists('driver', $config) && $config['driver'] == 's3') {
             $duration = $this->helper->config('temporary_url_duration');
-            return response()->streamDownload(function () {
-                echo file_get_contents($disk->temporaryUrl($file->path('storage'), now()->addMinutes($duration)));
+            return response()->streamDownload(function () use ($disk, $file, $duration) {
+                echo file_get_contents(
+                    $this->helper->config('s3_acls_disabled')
+                        ? $disk->url($file->path())
+                        : $disk->temporaryUrl($file->path(), now()->addMinutes($duration))
+                );
             }, $file_name);
         } else {
             return response()->download($file->path('absolute'));

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -336,7 +336,15 @@ class LfmPath
         $encoded_image = $this->imageService->read($original_image->get())
             ->cover($thumbWidth, $thumbHeight)
             ->encodeByMediaType();
-        
-        $this->storage->put($encoded_image, 'public');
+
+        $config = $this->storage->getConfig();
+        $options = 'public';
+        if (key_exists('driver', $config) && $config['driver'] == 's3'
+            && $this->helper->config('s3_acls_disabled')
+        ) {
+            $options = [];
+        }
+
+        $this->storage->put($encoded_image, $options);
     }
 }

--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -35,17 +35,27 @@ class LfmStorageRepository
 
     public function save($file)
     {
+        $config = $this->disk->getConfig();
+
         $nameint = strripos($this->path, "/");
         $nameclean = substr($this->path, $nameint + 1);
         $pathclean = substr_replace($this->path, "", $nameint);
-        $this->disk->putFileAs($pathclean, $file, $nameclean, 'public');
+        $options = 'public';
+        if (key_exists('driver', $config) && $config['driver'] == 's3'
+            && $this->helper->config('s3_acls_disabled')
+        ) {
+            $options = [];
+        }
+        $this->disk->putFileAs($pathclean, $file, $nameclean, $options);
     }
 
     public function url($path)
     {
         $config = $this->disk->getConfig();
 
-        if (key_exists('driver', $config) && $config['driver'] == 's3') {
+        if (key_exists('driver', $config) && $config['driver'] == 's3'
+			&& !$this->helper->config('s3_acls_disabled')
+        ) {
             $duration = $this->helper->config('temporary_url_duration');
             return $this->disk->temporaryUrl($path, now()->addMinutes($duration));
         } else {


### PR DESCRIPTION
### Background

AWS S3 now defaults to **Object Ownership = Bucket owner enforced**, which **disables ACLs** and requires access control to be done via **bucket policies and IAM** instead.

Laravel Filemanager currently assumes the legacy ACL model:

- Files are uploaded with visibility = public
- Flysystem converts that to x-amz-acl: public-read
- Signed URLs are used to access S3 objects

This works only when ACLs are enabled.
On **bucket-owner-enforced** buckets, AWS rejects any ACL header, causing uploads (including thumbnails) to fail or disappear.

### What this PR does

This PR adds support for modern AWS S3 buckets by introducing an opt-in flag:

`'s3_acls_disabled' => false,`

When enabled, LFM behaves in a way that matches AWS’s ACL-disabled ownership model.

**Behavior with s3_acls_disabled = false (default)**

Unchanged behavior:
- Uploads use visibility = public → ACL public-read
- Signed (temporary) URLs are generated
- Compatible with legacy ACL-based buckets

**Behavior with s3_acls_disabled = true**

Designed for Bucket owner enforced buckets:

- No ACL headers are sent on upload
- Bucket policies control public/private access
- Permanent URLs (disk->url()) are used instead of signed URLs
- Thumbnails and main files behave consistently

### Why this is needed

Flysystem currently maps visibility directly to S3 ACLs:

`public → x-amz-acl: public-read`

That model no longer works for AWS’s modern S3 configuration, where ACLs are completely disabled. The only correct way to make objects public in this mode is via **bucket policies**, which requires **no ACL headers at all**.

This PR makes LFM compatible with that AWS-recommended setup while keeping full backward compatibility.

### Example configuration

For a modern AWS S3 bucket:

`'s3_acls_disabled' => true,`

No other changes are required. Public access is controlled via the S3 bucket policy.

**Summary**

This PR allows Laravel Filemanager to work correctly with:

- Legacy ACL-based S3 buckets
- Modern **bucket-owner-enforced** S3 buckets

without breaking existing users or requiring changes to Flysystem.