### PR TITLE
Fix delete endpoint returning HTML 404 instead of JSON error

### DIFF
--- a/src/Controllers/DeleteController.php
+++ b/src/Controllers/DeleteController.php
@@ -23,14 +23,7 @@ class DeleteController extends LfmController
         $errors = [];
 
         foreach ($item_names as $name_to_delete) {
-            if (is_null($name_to_delete)) {
-                $errors[] = parent::error('folder-name');
-                continue;
-            }
-
             $file = $this->lfm->setName($name_to_delete);
-            $file_to_delete = $this->lfm->pretty($name_to_delete);
-            $file_path = $file_to_delete->path('absolute');
 
             if ($file->isDirectory()) {
                 event(new FolderIsDeleting($file->path('absolute')));
@@ -40,18 +33,25 @@ class DeleteController extends LfmController
             }
 
             if (!Storage::disk($this->helper->config('disk'))->exists($file->path('storage'))) {
-                $errors[] = parent::error('folder-not-found', ['folder' => $file_path]);
+                abort(404);
+            }
+
+            $file_to_delete = $this->lfm->pretty($name_to_delete);
+            $file_path = $file_to_delete->path('absolute');
+
+            if (is_null($name_to_delete)) {
+                array_push($errors, parent::error('folder-name'));
                 continue;
             }
 
-            if (!$this->lfm->setName($name_to_delete)->exists()) {
-                $errors[] = parent::error('folder-not-found', ['folder' => $file_path]);
+            if (! $this->lfm->setName($name_to_delete)->exists()) {
+                array_push($errors, parent::error('folder-not-found', ['folder' => $file_path]));
                 continue;
             }
 
             if ($this->lfm->setName($name_to_delete)->isDirectory()) {
-                if (!$this->lfm->setName($name_to_delete)->directoryIsEmpty()) {
-                    $errors[] = parent::error('delete-folder');
+                if (! $this->lfm->setName($name_to_delete)->directoryIsEmpty()) {
+                    array_push($errors, parent::error('delete-folder'));
                     continue;
                 }
 


### PR DESCRIPTION
Fixes issue #1276.

Previously the delete endpoint called abort(404) when the file did not exist on disk.
This returned an HTML response while the frontend expects JSON, which could cause
a JSON.parse error in the UI.

This change removes the abort(404) call and instead adds the error to the existing
$error array so the controller returns a proper JSON response.

This keeps error handling consistent with the rest of the controller logic.