### PR TITLE
Fix delete endpoint returning HTML 404 instead of JSON error

### DIFF
--- a/src/Controllers/DeleteController.php
+++ b/src/Controllers/DeleteController.php
@@ -32,12 +32,13 @@ class DeleteController extends LfmController
                 event(new ImageIsDeleting($file->path('absolute')));
             }
 
-            if (!Storage::disk($this->helper->config('disk'))->exists($file->path('storage'))) {
-                abort(404);
-            }
-
             $file_to_delete = $this->lfm->pretty($name_to_delete);
             $file_path = $file_to_delete->path('absolute');
+            
+            if (!Storage::disk($this->helper->config('disk'))->exists($file->path('storage'))) {
+                $errors[] = parent::error('folder-not-found', ['folder' => $file_path]);
+                continue;
+            }
 
             if (is_null($name_to_delete)) {
                 array_push($errors, parent::error('folder-name'));


### PR DESCRIPTION
Fixes #1276.

Previously the delete endpoint called abort(404) when the file did not exist on disk.
This returned an HTML response while the frontend expects JSON, which could cause a JSON.parse error.

This change replaces that behavior with the controller's existing JSON error flow, so the endpoint returns a proper JSON error response instead.