### PR TITLE
Improve file search handling

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -140,14 +140,24 @@ $(document).on('click', '[data-display]', function() {
 });
 
 $(document).on('click', '#keyword-button', function() {
-  show_list = $(this).data('display');
   loadItems();
 });
 
 $(document).on('click', '#keyword-reset-button', function() {
   $('#keyword').val("");
-  show_list = $(this).data('display');
   loadItems();
+});
+
+$(document).on('keydown', '#keyword', function(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    loadItems();
+  }
+
+  if (e.key === 'Escape') {
+    $(this).val('');
+    loadItems();
+  }
 });
 
 $(document).on('click', '[data-action]', function() {

--- a/src/Controllers/ItemsController.php
+++ b/src/Controllers/ItemsController.php
@@ -22,10 +22,10 @@ class ItemsController extends LfmController
         $perPage = $this->helper->getPaginationPerPage();
         $items = array_merge($this->lfm->folders(), $this->lfm->files());
 
-        $keyword = request()->input('keyword', '');
-        if (!empty($keyword)) {
+        $keyword = trim((string) request()->input('keyword', ''));
+        if ($keyword !== '') {
             $items = array_filter($items, function ($item) use ($keyword) {
-                return str_contains($item->name, $keyword);
+                return stripos($item->name, $keyword) !== false;
             });
         }
 


### PR DESCRIPTION
## Summary

Improves the existing file manager search behavior.

## What changed

- Trim the search keyword before filtering.
- Match filenames case-insensitively.
- Keep the current display mode unchanged when searching or resetting.
- Allow Enter to run the search from the keyword input.
- Allow Escape to clear the search and reload the folder.

## Why

The package already has a search box, but the current matching is exact-case and the search buttons can accidentally clear the selected display mode because they read `data-display` from buttons that do not define it.

This keeps the change small and focused on making the existing search behave more naturally.