### PR TITLE
Add opt-in upload image optimization and format conversion

### DIFF
--- a/config/lfm.php
+++ b/config/lfm.php
@@ -145,8 +145,11 @@ return [
      */
 
     // If true, supported images will be re-encoded during upload.
+    // Set format to convert uploads, for example "webp", "avif", "jpg", or "png".
+    // Also accepts "gif", "bmp", "tiff", "jp2", and "heic" when supported by the image driver.
     'optimize_uploaded_images' => [
         'enabled' => false,
+        'format' => null,
         'quality' => 85,
         'max_width' => null,
         'max_height' => null,
@@ -155,6 +158,13 @@ return [
         'mimetypes' => [
             'image/jpeg',
             'image/pjpeg',
+            'image/png',
+            'image/webp',
+            'image/avif',
+            'image/bmp',
+            'image/tiff',
+            'image/jp2',
+            'image/heic',
         ],
     ],
 

--- a/config/lfm.php
+++ b/config/lfm.php
@@ -147,6 +147,8 @@ return [
     // If true, supported images will be re-encoded during upload.
     // Set format to convert uploads, for example "webp", "avif", "jpg", or "png".
     // Also accepts "gif", "bmp", "tiff", "jp2", and "heic" when supported by the image driver.
+    // quality is only applied to jpeg, webp, and avif outputs and is clamped to 0..100.
+    // progressive only affects jpeg output.
     'optimize_uploaded_images' => [
         'enabled' => false,
         'format' => null,

--- a/config/lfm.php
+++ b/config/lfm.php
@@ -140,6 +140,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Image Optimization
+    |--------------------------------------------------------------------------
+     */
+
+    // If true, supported images will be re-encoded during upload.
+    'optimize_uploaded_images' => [
+        'enabled' => false,
+        'quality' => 85,
+        'max_width' => null,
+        'max_height' => null,
+        'progressive' => true,
+        'keep_original_when_larger' => true,
+        'mimetypes' => [
+            'image/jpeg',
+            'image/pjpeg',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Thumbnail
     |--------------------------------------------------------------------------
      */

--- a/config/lfm.php
+++ b/config/lfm.php
@@ -147,6 +147,7 @@ return [
     // If true, supported images will be re-encoded during upload.
     // Set format to convert uploads, for example "webp", "avif", "jpg", or "png".
     // Also accepts "gif", "bmp", "tiff", "jp2", and "heic" when supported by the image driver.
+    // GD WebP/AVIF output requires PHP's imagewebp()/imageavif() functions.
     // quality is only applied to jpeg, webp, and avif outputs and is clamped to 0..100.
     // progressive only affects jpeg output.
     'optimize_uploaded_images' => [

--- a/docs/config.md
+++ b/docs/config.md
@@ -219,7 +219,53 @@ GIF uploads are not included in the default `mimetypes` list because re-encoding
 
 `max_width` and `max_height` can be used to scale large uploads down while keeping the aspect ratio. Set both to `null` to keep the uploaded dimensions.
 
+`quality` is used for lossy output formats only: `jpg`, `webp`, and `avif`. The value is clamped to the `0..100` range, and non-numeric values fall back to `85`.
+
+`progressive` only affects JPEG output. Other formats ignore it.
+
 If optimization fails, the original upload is kept. If `keep_original_when_larger` is enabled, the optimized image only replaces the upload when it is smaller than the original. If conversion would overwrite an existing filename, the original upload is kept.
+
+Example verification scenarios:
+
+1. Keep JPEG format, resize large uploads, and use a lower quality setting:
+
+```
+'optimize_uploaded_images' => [
+    'enabled' => true,
+    'format' => null,
+    'quality' => 75,
+    'max_width' => 1600,
+    'max_height' => 1600,
+    'progressive' => true,
+],
+```
+
+Upload a large `.jpg`. Expected result: the stored file stays `.jpg`, dimensions are scaled down to fit within `1600x1600`, and the JPEG is re-encoded with quality `75`.
+
+2. Convert screenshots to WebP:
+
+```
+'optimize_uploaded_images' => [
+    'enabled' => true,
+    'format' => 'webp',
+    'quality' => 80,
+    'mimetypes' => ['image/png', 'image/jpeg', 'image/pjpeg'],
+],
+```
+
+Upload a `.png` or `.jpg`. Expected result: the stored file becomes `.webp`. `quality` is applied to the WebP output.
+
+3. Re-encode PNG without format conversion:
+
+```
+'optimize_uploaded_images' => [
+    'enabled' => true,
+    'format' => 'png',
+    'quality' => 30,
+],
+```
+
+Upload a `.png`. Expected result: the stored file stays `.png`. The `quality` setting does not change the code path here, because PNG uses the driver default encode options in this implementation.
 
 ## Thumbnail
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -189,6 +189,7 @@ Define behavior on files with identical name. Setting it to `true` cause old fil
 ```
 'optimize_uploaded_images' => [
     'enabled' => false,
+    'format' => null,
     'quality' => 85,
     'max_width' => null,
     'max_height' => null,
@@ -197,15 +198,28 @@ Define behavior on files with identical name. Setting it to `true` cause old fil
     'mimetypes' => [
         'image/jpeg',
         'image/pjpeg',
+        'image/png',
+        'image/webp',
+        'image/avif',
+        'image/bmp',
+        'image/tiff',
+        'image/jp2',
+        'image/heic',
     ],
 ],
 ```
 
 When `enabled` is `true`, supported uploaded images are re-encoded after the original upload succeeds.
 
+By default `format` is `null`, so the original image format is kept. Set `format` to an output format such as `jpg`, `png`, `webp`, or `avif` to convert supported uploads. Converted files use the matching extension, for example `photo.jpg` becomes `photo.webp` when `format` is `webp`.
+
+Driver-dependent formats such as `gif`, `bmp`, `tiff`, `jp2`, and `heic` are also accepted. If the configured GD or Imagick driver cannot encode the selected format, the original upload is kept.
+
+GIF uploads are not included in the default `mimetypes` list because re-encoding animated GIFs can change animation behavior depending on the driver. Add `image/gif` explicitly if that trade-off is acceptable for your application.
+
 `max_width` and `max_height` can be used to scale large uploads down while keeping the aspect ratio. Set both to `null` to keep the uploaded dimensions.
 
-If optimization fails, the original upload is kept. If `keep_original_when_larger` is enabled, the optimized image only replaces the upload when it is smaller than the original.
+If optimization fails, the original upload is kept. If `keep_original_when_larger` is enabled, the optimized image only replaces the upload when it is smaller than the original. If conversion would overwrite an existing filename, the original upload is kept.
 
 ## Thumbnail
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -179,6 +179,34 @@ If set to `true`, the mime type of uploading file will be verified.
 
 Define behavior on files with identical name. Setting it to `true` cause old file replace with new one. Setting it to `false` show `error-file-exist` error and abort the upload process.
 
+## Image Optimization
+
+### optimize\_uploaded\_images
+
+* type: `array`
+* default:
+
+```
+'optimize_uploaded_images' => [
+    'enabled' => false,
+    'quality' => 85,
+    'max_width' => null,
+    'max_height' => null,
+    'progressive' => true,
+    'keep_original_when_larger' => true,
+    'mimetypes' => [
+        'image/jpeg',
+        'image/pjpeg',
+    ],
+],
+```
+
+When `enabled` is `true`, supported uploaded images are re-encoded after the original upload succeeds.
+
+`max_width` and `max_height` can be used to scale large uploads down while keeping the aspect ratio. Set both to `null` to keep the uploaded dimensions.
+
+If optimization fails, the original upload is kept. If `keep_original_when_larger` is enabled, the optimized image only replaces the upload when it is smaller than the original.
+
 ## Thumbnail
 
 ### should\_create\_thumbnails

--- a/docs/config.md
+++ b/docs/config.md
@@ -215,6 +215,8 @@ By default `format` is `null`, so the original image format is kept. Set `format
 
 Driver-dependent formats such as `gif`, `bmp`, `tiff`, `jp2`, and `heic` are also accepted. If the configured GD or Imagick driver cannot encode the selected format, the original upload is kept.
 
+When the GD driver is used, WebP output requires PHP's `imagewebp()` function and AVIF output requires PHP's `imageavif()` function. If the installed GD extension does not provide the required encoder, the upload is kept unchanged and the reason is logged.
+
 GIF uploads are not included in the default `mimetypes` list because re-encoding animated GIFs can change animation behavior depending on the driver. Add `image/gif` explicitly if that trade-off is acceptable for your application.
 
 `max_width` and `max_height` can be used to scale large uploads down while keeping the aspect ratio. Set both to `null` to keep the uploaded dimensions.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,9 +25,9 @@
     composer require unisharp/laravel-filemanager
     ```
 
-1. (optional) Install required dependency with `v3.*` of `intervention/image`:
+1. (optional) Install required dependency with `v3.*` or `v4.*` of `intervention/image`:
 
-    This package use `intervention/image` to perform image cropping/resizing and generating thumbnails. Since `v3.*` of `intervention/image` does not support Laravel by default, the service provider need to be installed with the following scripts. Details can be found here: https://github.com/Intervention/image-laravel
+    This package use `intervention/image` to perform image cropping/resizing and generating thumbnails. Since `v3.*` and `v4.*` of `intervention/image` do not support Laravel by default, the service provider need to be installed with the following scripts. Details can be found here: https://github.com/Intervention/image-laravel
 
     ```bash
     composer require intervention/image-laravel
@@ -35,6 +35,7 @@
     ```
 
     \* *Do not run these scripts if you use `v2.*` of `intervention/image`.*
+    \* *`intervention/image` v4 requires PHP 8.3 or newer. Composer will keep v3 on older PHP versions.*
 
 1. Publish the package's config and assets :
 

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -4,7 +4,6 @@ namespace UniSharp\LaravelFilemanager;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
-use Intervention\Image\Facades\Image;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use UniSharp\LaravelFilemanager\Services\ImageService;
 use UniSharp\LaravelFilemanager\Events\FileIsUploading;
@@ -240,6 +239,8 @@ class LfmPath
         try {
             $this->setName($new_file_name)->storage->save($file);
 
+            $this->optimizeUploadedImage($new_file_name);
+
             $this->generateThumbnail($new_file_name);
         } catch (\Exception $e) {
             \Log::info($e);
@@ -278,6 +279,48 @@ class LfmPath
         }
 
         return true;
+    }
+
+    private function optimizeUploadedImage($file_name)
+    {
+        if (! config('lfm.optimize_uploaded_images.enabled', false)) {
+            return;
+        }
+
+        $original_image = $this->pretty($file_name);
+
+        if (!$original_image->isImage()) {
+            return;
+        }
+
+        $mime_type = $original_image->mimeType();
+        $allowed_mimetypes = (array) config(
+            'lfm.optimize_uploaded_images.mimetypes',
+            config('lfm.raster_mimetypes', [])
+        );
+
+        if (!in_array($mime_type, $allowed_mimetypes)) {
+            return;
+        }
+
+        try {
+            $contents = $original_image->get();
+            $optimized_image = $this->imageService->optimizeUpload(
+                $contents,
+                $mime_type,
+                config('lfm.optimize_uploaded_images', [])
+            );
+
+            if (config('lfm.optimize_uploaded_images.keep_original_when_larger', true)
+                && strlen((string) $optimized_image) >= strlen($contents)
+            ) {
+                return;
+            }
+
+            $this->setName($file_name)->storage->put($optimized_image, $this->storageOptions());
+        } catch (\Throwable $e) {
+            \Log::info($e);
+        }
     }
 
     private function getNewName($file)
@@ -347,14 +390,19 @@ class LfmPath
                 ->encodeByMediaType();
         }
 
+        $this->storage->put($encoded_image, $this->storageOptions());
+    }
+
+    private function storageOptions()
+    {
         $config = $this->storage->getConfig();
-        $options = 'public';
+
         if (key_exists('driver', $config) && $config['driver'] == 's3'
             && $this->helper->config('s3_acls_disabled')
         ) {
-            $options = [];
+            return [];
         }
 
-        $this->storage->put($encoded_image, $options);
+        return 'public';
     }
 }

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -239,13 +239,14 @@ class LfmPath
         try {
             $this->setName($new_file_name)->storage->save($file);
 
-            $this->optimizeUploadedImage($new_file_name);
+            $new_file_name = $this->optimizeUploadedImage($new_file_name);
 
             $this->generateThumbnail($new_file_name);
         } catch (\Exception $e) {
             \Log::info($e);
             return $this->error('invalid');
         }
+        $new_file_path = $this->setName($new_file_name)->path('absolute');
         event(new FileWasUploaded($new_file_path));
         event(new ImageWasUploaded($new_file_path));
 
@@ -284,13 +285,13 @@ class LfmPath
     private function optimizeUploadedImage($file_name)
     {
         if (! config('lfm.optimize_uploaded_images.enabled', false)) {
-            return;
+            return $file_name;
         }
 
         $original_image = $this->pretty($file_name);
 
         if (!$original_image->isImage()) {
-            return;
+            return $file_name;
         }
 
         $mime_type = $original_image->mimeType();
@@ -300,11 +301,12 @@ class LfmPath
         );
 
         if (!in_array($mime_type, $allowed_mimetypes)) {
-            return;
+            return $file_name;
         }
 
         try {
             $contents = $original_image->get();
+            $optimized_file_name = $this->optimizedFileName($file_name, $mime_type);
             $optimized_image = $this->imageService->optimizeUpload(
                 $contents,
                 $mime_type,
@@ -314,13 +316,45 @@ class LfmPath
             if (config('lfm.optimize_uploaded_images.keep_original_when_larger', true)
                 && strlen((string) $optimized_image) >= strlen($contents)
             ) {
-                return;
+                return $file_name;
             }
 
-            $this->setName($file_name)->storage->put($optimized_image, $this->storageOptions());
+            if ($optimized_file_name !== $file_name && $this->setName($optimized_file_name)->exists()) {
+                return $file_name;
+            }
+
+            $this->setName($optimized_file_name)->storage->put($optimized_image, $this->storageOptions());
+
+            if ($optimized_file_name !== $file_name) {
+                $this->setName($file_name)->delete();
+            }
+
+            return $optimized_file_name;
         } catch (\Throwable $e) {
             \Log::info($e);
         }
+
+        return $file_name;
+    }
+
+    private function optimizedFileName($file_name, $mime_type)
+    {
+        $format = config('lfm.optimize_uploaded_images.format');
+
+        if (!is_string($format) || $format === '') {
+            return $file_name;
+        }
+
+        $target_mime_type = $this->imageService->outputMimeType($mime_type, $format);
+        $extension = $this->imageService->extensionForMimeType($target_mime_type);
+
+        if ($extension === '') {
+            return $file_name;
+        }
+
+        $name = $this->helper->utf8Pathinfo($file_name, 'filename');
+
+        return $name . '.' . $extension;
     }
 
     private function getNewName($file)

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -3,7 +3,6 @@
 namespace UniSharp\LaravelFilemanager\Services;
 
 use Intervention\Image\Interfaces\ImageManagerInterface;
-use Intervention\Image\Image;
 
 class ImageService
 {
@@ -12,6 +11,56 @@ class ImageService
     public function __construct(ImageManagerInterface $imageManager)
     {
         $this->imageManager = $imageManager;
+    }
+
+    public function optimizeUpload(string $contents, string $mimeType, array $options)
+    {
+        $image = $this->imageManager->read($contents);
+
+        $maxWidth = $this->dimension($options['max_width'] ?? null);
+        $maxHeight = $this->dimension($options['max_height'] ?? null);
+
+        if ($maxWidth || $maxHeight) {
+            $image->scaleDown($maxWidth, $maxHeight);
+        }
+
+        $mimeType = $this->normalizeMimeType($mimeType);
+        $quality = $this->quality($options['quality'] ?? 85);
+
+        if ($mimeType === 'image/jpeg') {
+            return $image->encodeByMediaType(
+                $mimeType,
+                progressive: (bool) ($options['progressive'] ?? true),
+                quality: $quality
+            );
+        }
+
+        if (in_array($mimeType, ['image/webp', 'image/avif'])) {
+            return $image->encodeByMediaType($mimeType, quality: $quality);
+        }
+
+        return $image->encodeByMediaType($mimeType);
+    }
+
+    private function dimension($value): ?int
+    {
+        $value = (int) $value;
+
+        return $value > 0 ? $value : null;
+    }
+
+    private function quality($value): int
+    {
+        if (!is_numeric($value)) {
+            return 85;
+        }
+
+        return max(0, min(100, (int) $value));
+    }
+
+    private function normalizeMimeType(string $mimeType): string
+    {
+        return $mimeType === 'image/pjpeg' ? 'image/jpeg' : $mimeType;
     }
 
     /**

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -15,7 +15,7 @@ class ImageService
 
     public function optimizeUpload(string $contents, string $mimeType, array $options)
     {
-        $image = $this->imageManager->read($contents);
+        $image = $this->read($contents);
 
         $maxWidth = $this->dimension($options['max_width'] ?? null);
         $maxHeight = $this->dimension($options['max_height'] ?? null);
@@ -29,18 +29,86 @@ class ImageService
         $quality = $this->quality($options['quality'] ?? 85);
 
         if ($mimeType === 'image/jpeg') {
-            return $image->encodeByMediaType(
-                $mimeType,
-                progressive: (bool) ($options['progressive'] ?? true),
-                quality: $quality
-            );
+            return $this->encodeImageByMediaType($image, $mimeType, [
+                'progressive' => (bool) ($options['progressive'] ?? true),
+                'quality' => $quality,
+            ]);
         }
 
         if (in_array($mimeType, ['image/webp', 'image/avif'])) {
-            return $image->encodeByMediaType($mimeType, quality: $quality);
+            return $this->encodeImageByMediaType($image, $mimeType, [
+                'quality' => $quality,
+            ]);
         }
 
-        return $image->encodeByMediaType($mimeType);
+        return $this->encodeImageByMediaType($image, $mimeType);
+    }
+
+    public function read($source)
+    {
+        if (method_exists($this->imageManager, 'decode')) {
+            return $this->imageManager->decode($source);
+        }
+
+        return $this->imageManager->read($source);
+    }
+
+    public function decode($source)
+    {
+        return $this->read($source);
+    }
+
+    public function decodePath($path)
+    {
+        if (method_exists($this->imageManager, 'decodePath')) {
+            return $this->imageManager->decodePath($path);
+        }
+
+        return $this->imageManager->read((string) $path);
+    }
+
+    private function encodeImageByMediaType($image, string $mimeType, array $options = [])
+    {
+        $this->ensureEncodingSupport($mimeType);
+
+        if (method_exists($image, 'encodeUsingMediaType')) {
+            return $image->encodeUsingMediaType($mimeType, ...$options);
+        }
+
+        return $image->encodeByMediaType($mimeType, ...$options);
+    }
+
+    private function ensureEncodingSupport(string $mimeType): void
+    {
+        if (! $this->usesGdDriver()) {
+            return;
+        }
+
+        $requiredFunction = match ($mimeType) {
+            'image/webp' => 'imagewebp',
+            'image/avif' => 'imageavif',
+            default => null,
+        };
+
+        if ($requiredFunction !== null && ! function_exists($requiredFunction)) {
+            throw new \RuntimeException(
+                "Cannot encode {$mimeType} with the GD driver because PHP's {$requiredFunction}() "
+                    . 'function is not available.'
+            );
+        }
+    }
+
+    private function usesGdDriver(): bool
+    {
+        $driver = null;
+
+        if (method_exists($this->imageManager, 'driver')) {
+            $driver = $this->imageManager->driver();
+        } elseif (isset($this->imageManager->driver)) {
+            $driver = $this->imageManager->driver;
+        }
+
+        return is_object($driver) && str_contains($driver::class, '\\Drivers\\Gd\\');
     }
 
     private function dimension($value): ?int

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -24,7 +24,8 @@ class ImageService
             $image->scaleDown($maxWidth, $maxHeight);
         }
 
-        $mimeType = $this->normalizeMimeType($mimeType);
+        $format = $options['format'] ?? null;
+        $mimeType = $this->outputMimeType($mimeType, is_string($format) ? $format : null);
         $quality = $this->quality($options['quality'] ?? 85);
 
         if ($mimeType === 'image/jpeg') {
@@ -56,6 +57,42 @@ class ImageService
         }
 
         return max(0, min(100, (int) $value));
+    }
+
+    public function outputMimeType(string $mimeType, ?string $format = null): string
+    {
+        if (is_string($format) && $format !== '') {
+            return match (strtolower($format)) {
+                'jpg', 'jpeg', 'image/jpeg' => 'image/jpeg',
+                'png', 'image/png' => 'image/png',
+                'webp', 'image/webp' => 'image/webp',
+                'avif', 'image/avif' => 'image/avif',
+                'gif', 'image/gif' => 'image/gif',
+                'bmp', 'bitmap', 'image/bmp' => 'image/bmp',
+                'tif', 'tiff', 'image/tiff' => 'image/tiff',
+                'jp2', 'jpx', 'jpeg2000', 'jpeg 2000', 'image/jp2' => 'image/jp2',
+                'heic', 'image/heic' => 'image/heic',
+                default => $this->normalizeMimeType($mimeType),
+            };
+        }
+
+        return $this->normalizeMimeType($mimeType);
+    }
+
+    public function extensionForMimeType(string $mimeType): string
+    {
+        return match ($this->normalizeMimeType($mimeType)) {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/webp' => 'webp',
+            'image/avif' => 'avif',
+            'image/gif' => 'gif',
+            'image/bmp' => 'bmp',
+            'image/tiff' => 'tiff',
+            'image/jp2' => 'jp2',
+            'image/heic' => 'heic',
+            default => '',
+        };
     }
 
     private function normalizeMimeType(string $mimeType): string

--- a/tests/ImageServiceTest.php
+++ b/tests/ImageServiceTest.php
@@ -2,85 +2,196 @@
 
 namespace Tests;
 
-use Intervention\Image\Interfaces\ImageManagerInterface;
-use Mockery as m;
+use Intervention\Image\ImageManager;
 use PHPUnit\Framework\TestCase;
 use UniSharp\LaravelFilemanager\Services\ImageService;
 
 class ImageServiceTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        m::close();
+    private ImageService $service;
 
-        parent::tearDown();
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ImageService(ImageManager::gd());
     }
 
     public function testOptimizesUploadWithConfiguredDimensions()
     {
-        $manager = m::mock(ImageManagerInterface::class);
-        $image = m::mock();
-
-        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
-        $image->shouldReceive('scaleDown')->with(1200, 900)->once()->andReturn($image);
-        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
-
-        $service = new ImageService($manager);
-
-        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/pjpeg', [
-            'quality' => 80,
+        $encoded = $this->service->optimizeUpload($this->createDetailedJpeg(), 'image/jpeg', [
             'max_width' => 1200,
             'max_height' => 900,
-        ]));
-    }
+            'quality' => 85,
+            'progressive' => false,
+        ]);
 
-    public function testOptimizesUploadWithoutResizing()
-    {
-        $manager = m::mock(ImageManagerInterface::class);
-        $image = m::mock();
+        $image = $this->service->read((string) $encoded);
 
-        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
-        $image->shouldNotReceive('scaleDown');
-        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
-
-        $service = new ImageService($manager);
-
-        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/jpeg', [
-            'quality' => 80,
-        ]));
+        $this->assertSame('image/jpeg', $encoded->mediaType());
+        $this->assertSame(1200, $image->width());
+        $this->assertSame(720, $image->height());
     }
 
     public function testCanConvertUploadsToConfiguredFormat()
     {
-        $manager = m::mock(ImageManagerInterface::class);
-        $image = m::mock();
+        $encoded = $this->service->optimizeUpload($this->createDetailedPng(), 'image/png', [
+            'format' => 'jpg',
+            'quality' => 72,
+            'progressive' => true,
+        ]);
 
-        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
-        $image->shouldNotReceive('scaleDown');
-        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
+        $this->assertSame('image/jpeg', $encoded->mediaType());
+        $this->assertSame('image/jpeg', $this->service->outputMimeType('image/png', 'jpg'));
+        $this->assertSame('webp', $this->service->extensionForMimeType('image/webp'));
+        $this->assertJpegUsesProgressiveEncoding((string) $encoded);
+    }
 
-        $service = new ImageService($manager);
+    public function testJpegQualityIsClampedToHundred()
+    {
+        $source = $this->createDetailedJpeg();
 
-        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/png', [
-            'format' => 'avif',
+        $encoded = $this->service->optimizeUpload($source, 'image/jpeg', [
+            'quality' => 100,
+            'progressive' => false,
+        ]);
+
+        $clamped = $this->service->optimizeUpload($source, 'image/jpeg', [
+            'quality' => 140,
+            'progressive' => false,
+        ]);
+
+        $this->assertSame('image/jpeg', $clamped->mediaType());
+        $this->assertSame((string) $encoded, (string) $clamped);
+    }
+
+    public function testJpegProgressiveOptionChangesEncodingMode()
+    {
+        $source = $this->createDetailedJpeg();
+
+        $progressive = $this->service->optimizeUpload($source, 'image/jpeg', [
             'quality' => 80,
-        ]));
-        $this->assertSame('image/avif', $service->outputMimeType('image/png', 'avif'));
-        $this->assertSame('webp', $service->extensionForMimeType('image/webp'));
+            'progressive' => true,
+        ]);
+
+        $baseline = $this->service->optimizeUpload($source, 'image/jpeg', [
+            'quality' => 80,
+            'progressive' => false,
+        ]);
+
+        $this->assertJpegUsesProgressiveEncoding((string) $progressive);
+        $this->assertJpegUsesBaselineEncoding((string) $baseline);
+    }
+
+    public function testPngOptimizationIgnoresQualityAndProgressiveOptions()
+    {
+        $source = $this->createDetailedPng();
+
+        $encoded = $this->service->optimizeUpload($source, 'image/png', [
+            'quality' => 30,
+            'progressive' => false,
+        ]);
+
+        $withDifferentOptions = $this->service->optimizeUpload($source, 'image/png', [
+            'quality' => 90,
+            'progressive' => true,
+        ]);
+
+        $this->assertSame('image/png', $encoded->mediaType());
+        $this->assertSame((string) $encoded, (string) $withDifferentOptions);
     }
 
     public function testRecognizesConfiguredOutputFormats()
     {
-        $service = new ImageService(m::mock(ImageManagerInterface::class));
+        $this->assertSame('image/jpeg', $this->service->outputMimeType('image/png', 'jpg'));
+        $this->assertSame('image/png', $this->service->outputMimeType('image/jpeg', 'png'));
+        $this->assertSame('image/webp', $this->service->outputMimeType('image/jpeg', 'webp'));
+        $this->assertSame('image/avif', $this->service->outputMimeType('image/jpeg', 'avif'));
+        $this->assertSame('image/gif', $this->service->outputMimeType('image/jpeg', 'gif'));
+        $this->assertSame('image/bmp', $this->service->outputMimeType('image/jpeg', 'bmp'));
+        $this->assertSame('image/tiff', $this->service->outputMimeType('image/jpeg', 'tiff'));
+        $this->assertSame('image/jp2', $this->service->outputMimeType('image/jpeg', 'jp2'));
+        $this->assertSame('image/heic', $this->service->outputMimeType('image/jpeg', 'heic'));
+    }
 
-        $this->assertSame('image/jpeg', $service->outputMimeType('image/png', 'jpg'));
-        $this->assertSame('image/png', $service->outputMimeType('image/jpeg', 'png'));
-        $this->assertSame('image/webp', $service->outputMimeType('image/jpeg', 'webp'));
-        $this->assertSame('image/avif', $service->outputMimeType('image/jpeg', 'avif'));
-        $this->assertSame('image/gif', $service->outputMimeType('image/jpeg', 'gif'));
-        $this->assertSame('image/bmp', $service->outputMimeType('image/jpeg', 'bmp'));
-        $this->assertSame('image/tiff', $service->outputMimeType('image/jpeg', 'tiff'));
-        $this->assertSame('image/jp2', $service->outputMimeType('image/jpeg', 'jp2'));
-        $this->assertSame('image/heic', $service->outputMimeType('image/jpeg', 'heic'));
+    private function createDetailedJpeg(int $width = 2000, int $height = 1200): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+
+        for ($y = 0; $y < $height; $y += 40) {
+            for ($x = 0; $x < $width; $x += 40) {
+                $color = imagecolorallocate(
+                    $image,
+                    ($x * 13 + $y * 7) % 256,
+                    ($x * 5 + $y * 11) % 256,
+                    ($x * 3 + $y * 17) % 256
+                );
+
+                imagefilledrectangle($image, $x, $y, min($width - 1, $x + 39), min($height - 1, $y + 39), $color);
+            }
+        }
+
+        $jpeg = $this->captureImageOutput(static function ($handle): void {
+            imagejpeg($handle, null, 95);
+        }, $image);
+
+        imagedestroy($image);
+
+        return $jpeg;
+    }
+
+    private function createDetailedPng(int $width = 800, int $height = 500): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+
+        for ($y = 0; $y < $height; $y += 25) {
+            for ($x = 0; $x < $width; $x += 25) {
+                $color = imagecolorallocatealpha(
+                    $image,
+                    ($x * 9 + $y * 5) % 256,
+                    ($x * 7 + $y * 3) % 256,
+                    ($x * 11 + $y * 13) % 256,
+                    ($x + $y) % 64
+                );
+
+                imagefilledrectangle($image, $x, $y, min($width - 1, $x + 24), min($height - 1, $y + 24), $color);
+            }
+        }
+
+        $png = $this->captureImageOutput(static function ($handle): void {
+            imagepng($handle);
+        }, $image);
+
+        imagedestroy($image);
+
+        return $png;
+    }
+
+    private function captureImageOutput(callable $encoder, $image): string
+    {
+        ob_start();
+        $encoder($image);
+
+        return (string) ob_get_clean();
+    }
+
+    private function assertJpegUsesProgressiveEncoding(string $jpeg): void
+    {
+        $this->assertNotFalse(strpos($this->jpegHeaders($jpeg), "\xFF\xC2"));
+    }
+
+    private function assertJpegUsesBaselineEncoding(string $jpeg): void
+    {
+        $this->assertNotFalse(strpos($this->jpegHeaders($jpeg), "\xFF\xC0"));
+    }
+
+    private function jpegHeaders(string $jpeg): string
+    {
+        $startOfScan = strpos($jpeg, "\xFF\xDA");
+
+        return $startOfScan === false ? $jpeg : substr($jpeg, 0, $startOfScan);
     }
 }

--- a/tests/ImageServiceTest.php
+++ b/tests/ImageServiceTest.php
@@ -49,4 +49,38 @@ class ImageServiceTest extends TestCase
             'quality' => 80,
         ]));
     }
+
+    public function testCanConvertUploadsToConfiguredFormat()
+    {
+        $manager = m::mock(ImageManagerInterface::class);
+        $image = m::mock();
+
+        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
+        $image->shouldNotReceive('scaleDown');
+        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
+
+        $service = new ImageService($manager);
+
+        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/png', [
+            'format' => 'avif',
+            'quality' => 80,
+        ]));
+        $this->assertSame('image/avif', $service->outputMimeType('image/png', 'avif'));
+        $this->assertSame('webp', $service->extensionForMimeType('image/webp'));
+    }
+
+    public function testRecognizesConfiguredOutputFormats()
+    {
+        $service = new ImageService(m::mock(ImageManagerInterface::class));
+
+        $this->assertSame('image/jpeg', $service->outputMimeType('image/png', 'jpg'));
+        $this->assertSame('image/png', $service->outputMimeType('image/jpeg', 'png'));
+        $this->assertSame('image/webp', $service->outputMimeType('image/jpeg', 'webp'));
+        $this->assertSame('image/avif', $service->outputMimeType('image/jpeg', 'avif'));
+        $this->assertSame('image/gif', $service->outputMimeType('image/jpeg', 'gif'));
+        $this->assertSame('image/bmp', $service->outputMimeType('image/jpeg', 'bmp'));
+        $this->assertSame('image/tiff', $service->outputMimeType('image/jpeg', 'tiff'));
+        $this->assertSame('image/jp2', $service->outputMimeType('image/jpeg', 'jp2'));
+        $this->assertSame('image/heic', $service->outputMimeType('image/jpeg', 'heic'));
+    }
 }

--- a/tests/ImageServiceTest.php
+++ b/tests/ImageServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use Intervention\Image\ImageManager;
 use PHPUnit\Framework\TestCase;
 use UniSharp\LaravelFilemanager\Services\ImageService;
@@ -14,7 +15,7 @@ class ImageServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->service = new ImageService(ImageManager::gd());
+        $this->service = new ImageService(new ImageManager(new GdDriver()));
     }
 
     public function testOptimizesUploadWithConfiguredDimensions()
@@ -114,6 +115,21 @@ class ImageServiceTest extends TestCase
         $this->assertSame('image/heic', $this->service->outputMimeType('image/jpeg', 'heic'));
     }
 
+    public function testWebpConversionReportsMissingGdSupport()
+    {
+        if (function_exists('imagewebp')) {
+            $this->markTestSkipped('GD WebP support is available.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("PHP's imagewebp() function is not available");
+
+        $this->service->optimizeUpload($this->createDetailedPng(), 'image/png', [
+            'format' => 'webp',
+            'quality' => 80,
+        ]);
+    }
+
     private function createDetailedJpeg(int $width = 2000, int $height = 1200): string
     {
         $image = imagecreatetruecolor($width, $height);
@@ -135,7 +151,7 @@ class ImageServiceTest extends TestCase
             imagejpeg($handle, null, 95);
         }, $image);
 
-        imagedestroy($image);
+        $this->destroyImage($image);
 
         return $jpeg;
     }
@@ -165,7 +181,7 @@ class ImageServiceTest extends TestCase
             imagepng($handle);
         }, $image);
 
-        imagedestroy($image);
+        $this->destroyImage($image);
 
         return $png;
     }
@@ -176,6 +192,13 @@ class ImageServiceTest extends TestCase
         $encoder($image);
 
         return (string) ob_get_clean();
+    }
+
+    private function destroyImage($image): void
+    {
+        if (PHP_VERSION_ID < 80500) {
+            imagedestroy($image);
+        }
     }
 
     private function assertJpegUsesProgressiveEncoding(string $jpeg): void

--- a/tests/ImageServiceTest.php
+++ b/tests/ImageServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests;
+
+use Intervention\Image\Interfaces\ImageManagerInterface;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use UniSharp\LaravelFilemanager\Services\ImageService;
+
+class ImageServiceTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testOptimizesUploadWithConfiguredDimensions()
+    {
+        $manager = m::mock(ImageManagerInterface::class);
+        $image = m::mock();
+
+        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
+        $image->shouldReceive('scaleDown')->with(1200, 900)->once()->andReturn($image);
+        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
+
+        $service = new ImageService($manager);
+
+        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/pjpeg', [
+            'quality' => 80,
+            'max_width' => 1200,
+            'max_height' => 900,
+        ]));
+    }
+
+    public function testOptimizesUploadWithoutResizing()
+    {
+        $manager = m::mock(ImageManagerInterface::class);
+        $image = m::mock();
+
+        $manager->shouldReceive('read')->with('contents')->once()->andReturn($image);
+        $image->shouldNotReceive('scaleDown');
+        $image->shouldReceive('encodeByMediaType')->once()->andReturn('encoded');
+
+        $service = new ImageService($manager);
+
+        $this->assertSame('encoded', $service->optimizeUpload('contents', 'image/jpeg', [
+            'quality' => 80,
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

This adds an optional image optimization step for uploaded images.

When enabled, uploaded images can be re-encoded, resized within configured dimensions, and optionally converted to another format such as `jpg`, `png`, `webp`, or `avif`.

The feature is disabled by default, so existing installs keep the same upload behavior unless they explicitly enable it.

## What changed

- Added a new `optimize_uploaded_images` config section.
- Re-encode supported image uploads after the original upload succeeds.
- Support optional format conversion through config.
- Support optional `max_width` and `max_height` resizing while preserving aspect ratio.
- Keep the original uploaded file when optimization is not safe to apply.
- Documented the new config options.
- Added test coverage for output format selection.

## Fallback behavior

The original upload is kept if optimization fails, if the optimized file is larger, if the selected format cannot be encoded by the current image driver, or if conversion would overwrite an existing file.

## Why

Some projects receive large user-uploaded images and need a simple way to reduce file size or normalize image formats during upload.

This keeps the behavior opt-in, so projects that do not need image processing are not affected.