### PR TITLE
[2.x] Add support for intervention image v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,14 @@
         "php": ">=8.1",
         "ext-exif": "*",
         "ext-fileinfo": "*",
-        "intervention/image": ">=3.11.3",
+        "intervention/image": ">=3.11.3 <5.0.0",
         "illuminate/config": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/filesystem": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/http": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/container": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "league/flysystem": ">=2.0.0"
+        "league/flysystem": ">=2.0.0",
+        "composer/semver": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",

--- a/src/Controllers/CropController.php
+++ b/src/Controllers/CropController.php
@@ -52,7 +52,7 @@ class CropController extends LfmController
         $crop_info = request()->only('dataWidth', 'dataHeight', 'dataX', 'dataY');
 
         $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
-        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+        if (Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
             $this->imageService
                 ->decodePath($image_path)
                 ->crop(...array_values($crop_info))

--- a/src/Controllers/CropController.php
+++ b/src/Controllers/CropController.php
@@ -5,6 +5,8 @@ namespace UniSharp\LaravelFilemanager\Controllers;
 use UniSharp\LaravelFilemanager\Services\ImageService;
 use UniSharp\LaravelFilemanager\Events\ImageIsCropping;
 use UniSharp\LaravelFilemanager\Events\ImageWasCropped;
+use Composer\InstalledVersions;
+use Composer\Semver\Comparator;
 
 class CropController extends LfmController
 {
@@ -49,9 +51,18 @@ class CropController extends LfmController
 
         $crop_info = request()->only('dataWidth', 'dataHeight', 'dataX', 'dataY');
 
-        $this->imageService->read($image_path)
-            ->crop(...array_values($crop_info))
-            ->save($crop_path);
+        $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
+        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+            $this->imageService
+                ->decodePath($image_path)
+                ->crop(...array_values($crop_info))
+                ->save($crop_path);
+        } else {
+            $this->imageService
+                ->read($image_path)
+                ->crop(...array_values($crop_info))
+                ->save($crop_path);
+        }
 
         // make new thumbnail
         $this->lfm->generateThumbnail($image_name);

--- a/src/Controllers/ResizeController.php
+++ b/src/Controllers/ResizeController.php
@@ -77,7 +77,7 @@ class ResizeController extends LfmController
         event(new ImageIsResizing($image_path));
 
         $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
-        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+        if (Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
             $this->imageService
                 ->decodePath($image_path)
                 ->resize(request('dataWidth'), request('dataHeight'))

--- a/src/Controllers/ResizeController.php
+++ b/src/Controllers/ResizeController.php
@@ -5,6 +5,8 @@ namespace UniSharp\LaravelFilemanager\Controllers;
 use UniSharp\LaravelFilemanager\Services\ImageService;
 use UniSharp\LaravelFilemanager\Events\ImageIsResizing;
 use UniSharp\LaravelFilemanager\Events\ImageWasResized;
+use Composer\InstalledVersions;
+use Composer\Semver\Comparator;
 
 class ResizeController extends LfmController
 {
@@ -74,9 +76,18 @@ class ResizeController extends LfmController
 
         event(new ImageIsResizing($image_path));
 
-        $this->imageService->read($image_path)
-            ->resize(request('dataWidth'), request('dataHeight'))
-            ->save($resize_path);
+        $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
+        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+            $this->imageService
+                ->decodePath($image_path)
+                ->resize(request('dataWidth'), request('dataHeight'))
+                ->save($resize_path);
+        } else {
+            $this->imageService
+                ->read($image_path)
+                ->resize(request('dataWidth'), request('dataHeight'))
+                ->save($resize_path);
+        }
 
         event(new ImageWasResized($image_path));
 

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -336,7 +336,7 @@ class LfmPath
         $thumbHeight = $this->helper->shouldCreateCategoryThumb() && $this->helper->categoryThumbHeight() ? $this->helper->categoryThumbHeight() : config('lfm.thumb_img_height', 200);
 
         $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
-        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+        if (Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
             $encoded_image = $this->imageService
                 ->decode($original_image->get())
                 ->cover($thumbWidth, $thumbHeight)

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -12,6 +12,8 @@ use UniSharp\LaravelFilemanager\Events\FileWasUploaded;
 use UniSharp\LaravelFilemanager\Events\ImageIsUploading;
 use UniSharp\LaravelFilemanager\Events\ImageWasUploaded;
 use UniSharp\LaravelFilemanager\LfmUploadValidator;
+use Composer\InstalledVersions;
+use Composer\Semver\Comparator;
 
 class LfmPath
 {
@@ -333,9 +335,17 @@ class LfmPath
         $thumbWidth = $this->helper->shouldCreateCategoryThumb() && $this->helper->categoryThumbWidth() ? $this->helper->categoryThumbWidth() : config('lfm.thumb_img_width', 200);
         $thumbHeight = $this->helper->shouldCreateCategoryThumb() && $this->helper->categoryThumbHeight() ? $this->helper->categoryThumbHeight() : config('lfm.thumb_img_height', 200);
 
-        $encoded_image = $this->imageService->read($original_image->get())
-            ->cover($thumbWidth, $thumbHeight)
-            ->encodeByMediaType();
+        $installedInterventionImageVersion = InstalledVersions::getPrettyVersion('intervention/image');
+        if(Comparator::greaterThanOrEqualTo($installedInterventionImageVersion, '4.0.0')) {
+            $encoded_image = $this->imageService
+                ->decode($original_image->get())
+                ->cover($thumbWidth, $thumbHeight)
+                ->encodeUsingMediaType($original_image->mimeType());
+        } else {
+            $encoded_image = $this->imageService->read($original_image->get())
+                ->cover($thumbWidth, $thumbHeight)
+                ->encodeByMediaType();
+        }
 
         $config = $this->storage->getConfig();
         $options = 'public';


### PR DESCRIPTION
#### Summary of the change:

Added a version constraint to the `composer.json` to not allow intervention image 5.0.0 (for when it exists, see below though). Updated the usage of intervention image to support the new syntax. Due to the version constraint I have considered this a bug so am doing a comparison via Composer to determine which syntax to use. This is because `>=3.11.3` allows 4.0.0 during an upgrade.

Personally, I feel that this should be considered as a "fix" under the `2.x.x` cycle on the filemanager, with `3.x.x` maybe dropping support for intervention v3. If this does happen, please may I also suggest that the `composer.json` is updated to reflect that the package is tested with version 4, by setting the constraint to `^4.0.0`. This way if `5.x` of intervention has additional breaking changes then it can be added as needed without any users accidently pulling in the new version.

I'm currently working around this with a production app by manually overwriting the `LfmPath` and `CropController`, in this app I had missed the `ResizeController` but have also updated that in this PR too.

An alternative approach I did consider is to instead overwrite the methods within the image service and then that service can do the required mapping depending on the version. Personally, I feel this is misleading given the service for the most part proxies the intervention class. However, I'm happy to refactor to that if preferred.

If you'd like me to also raise a PR for a 3.x version to drop support for both and only support v4, let me know and I'd be happy to get that created when I have some time.

I've tested these changes by pulling my branch into a local version of the production app and verified both on intervention image v4 and v3.

Adding support for v4 will require https://github.com/UniSharp/laravel-filemanager/pull/1291 to be updated.