### PR TITLE
Feat: add ascending/descending sort options for name and time

### DIFF
--- a/resources/lang/ar/lfm.php
+++ b/resources/lang/ar/lfm.php
@@ -6,6 +6,13 @@ return [
     'nav-upload'        => 'رفع',
     'nav-thumbnails'    => 'مصغرات',
     'nav-list'          => 'قائمة',
+    'nav-sort'          => 'ترتيب',
+    'nav-sort-alphabetic'=> 'ترتيب أبجدي',
+    'nav-sort-time'     => 'ترتيب حسب الوقت',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'الأقدم أولاً',
+    'nav-sort-newest-first' => 'الأحدث أولاً',
 
     'menu-rename'       => 'إعادة تسمية',
     'menu-delete'       => 'حذف',

--- a/resources/lang/az/lfm.php
+++ b/resources/lang/az/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sırala',
     'nav-sort-alphabetic'=> 'A-Z Sırala',
     'nav-sort-time'     => 'Zamana Görə Sırala',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Əvvəlcə köhnələr',
+    'nav-sort-newest-first' => 'Əvvəlcə yenilər',
 
     'menu-rename'       => 'Ad dəyişmək',
     'menu-delete'       => 'Sil',

--- a/resources/lang/bg/lfm.php
+++ b/resources/lang/bg/lfm.php
@@ -6,6 +6,13 @@ return [
     'nav-upload'        => 'Качване',
     'nav-thumbnails'    => 'Тъмб',
     'nav-list'          => 'Списък',
+    'nav-sort'          => 'Сортиране',
+    'nav-sort-alphabetic'=> 'По азбучен ред',
+    'nav-sort-time'     => 'По време',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Първо най-старите',
+    'nav-sort-newest-first' => 'Първо най-новите',
 
     'menu-rename'       => 'Преименувай',
     'menu-delete'       => 'Изтрии',

--- a/resources/lang/bn/lfm.php
+++ b/resources/lang/bn/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'সাজান',
     'nav-sort-alphabetic'=> 'বর্ণানুক্রমিক সাজান',
     'nav-sort-time'     => 'সময় অনুযায়ী সাজান',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'পুরনো প্রথমে',
+    'nav-sort-newest-first' => 'নতুন প্রথমে',
 
     'menu-rename'       => 'পুনঃনামকরণ',
     'menu-delete'       => 'মুছুন',

--- a/resources/lang/cs/lfm.php
+++ b/resources/lang/cs/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Seřadit',
     'nav-sort-alphabetic'=> 'Seřadit podle abecedy',
     'nav-sort-time'     => 'Seřadit podle času',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Nejstarší první',
+    'nav-sort-newest-first' => 'Nejnovější první',
 
     'menu-rename'       => 'Přejmenovat',
     'menu-delete'       => 'Smazat',

--- a/resources/lang/da/lfm.php
+++ b/resources/lang/da/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sorter',
     'nav-sort-alphabetic'=> 'Sorter alfabetisk',
     'nav-sort-time'     => 'Sort efter dato',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Ældste først',
+    'nav-sort-newest-first' => 'Nyeste først',
 
     'menu-rename'       => 'Omdøb',
     'menu-delete'       => 'Slet',

--- a/resources/lang/de/lfm.php
+++ b/resources/lang/de/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'                    => 'Sortierung',
     'nav-sort-alphabetic'         => 'Alphabetisch',
     'nav-sort-time'               => 'Datum',
+    'nav-sort-z-to-a'             => 'Z-A',
+    'nav-sort-a-to-z'             => 'A-Z',
+    'nav-sort-oldest-first'       => 'Älteste zuerst',
+    'nav-sort-newest-first'       => 'Neueste zuerst',
 
     'menu-rename'                 => 'Umbenennen',
     'menu-delete'                 => 'Löschen',

--- a/resources/lang/el/lfm.php
+++ b/resources/lang/el/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Ταξινόμηση',
     'nav-sort-alphabetic'=> 'Ταξινόμηση (αλφαβητικά)',
     'nav-sort-time'     => 'Ταξινόμηση (ημερομηνία)',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Παλαιότερα πρώτα',
+    'nav-sort-newest-first' => 'Νεότερα πρώτα',
 
     'menu-rename'       => 'Μετονομασία',
     'menu-delete'       => 'Διαγραφή',

--- a/resources/lang/en/lfm.php
+++ b/resources/lang/en/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sort',
     'nav-sort-alphabetic'=> 'Sort By Alphabets',
     'nav-sort-time'     => 'Sort By Time',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Oldest first',
+    'nav-sort-newest-first' => 'Newest first',
 
     'menu-rename'       => 'Rename',
     'menu-delete'       => 'Delete',

--- a/resources/lang/es/lfm.php
+++ b/resources/lang/es/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Ordenar',
     'nav-sort-alphabetic'=> 'Ordenar Alfabéticamente',
     'nav-sort-time'     => 'Ordenar por Fecha',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Más antiguos primero',
+    'nav-sort-newest-first' => 'Más recientes primero',
 
     'menu-rename'       => 'Cambiar Nombre',
     'menu-delete'       => 'Eliminar',

--- a/resources/lang/eu/lfm.php
+++ b/resources/lang/eu/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Ordenatu',
     'nav-sort-alphabetic'=> 'Ordenatu alfabetikoki',
     'nav-sort-time'     => 'Ordenatu denboraren arabera',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Zaharrenak lehenik',
+    'nav-sort-newest-first' => 'Berrienak lehenik',
 
     'menu-rename'       => 'Aldatu izena',
     'menu-delete'       => 'Ezabatu',

--- a/resources/lang/fa/lfm.php
+++ b/resources/lang/fa/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'مرتب سازی',
     'nav-sort-alphabetic'=> 'مرتب سازی الفبایی',
     'nav-sort-time'     => 'مرتب سازی زمانی',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'قدیمی‌ترین اول',
+    'nav-sort-newest-first' => 'جدیدترین اول',
 
     'menu-rename'       => 'تغییر نام',
     'menu-delete'       => 'حذف',

--- a/resources/lang/fi/lfm.php
+++ b/resources/lang/fi/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Järjestä',
     'nav-sort-alphabetic' => 'Lajittele aakkosten mukaan',
     'nav-sort-time'     => 'Lajittele ajan mukaan ',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Vanhimmat ensin',
+    'nav-sort-newest-first' => 'Uusimmat ensin',
 
     'menu-rename'       => 'Nimeä uudestaan',
     'menu-delete'       => 'Poista',

--- a/resources/lang/fr/lfm.php
+++ b/resources/lang/fr/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Trier',
     'nav-sort-alphabetic'=> 'Trier par ordre alphabétique',
     'nav-sort-time'     => 'Trier par date',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Plus anciens d\'abord',
+    'nav-sort-newest-first' => 'Plus récents d\'abord',
 
     'menu-rename'       => 'Renommer',
     'menu-delete'       => 'Effacer',

--- a/resources/lang/he/lfm.php
+++ b/resources/lang/he/lfm.php
@@ -6,6 +6,13 @@ return [
     'nav-upload'        => 'העלה',
     'nav-thumbnails'    => 'תמונות ממוזערות',
     'nav-list'          => 'רשימה',
+    'nav-sort'          => 'מיון',
+    'nav-sort-alphabetic'=> 'מיון לפי א-ב',
+    'nav-sort-time'     => 'מיון לפי זמן',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'הישנים ביותר תחילה',
+    'nav-sort-newest-first' => 'החדשים ביותר תחילה',
 
     'menu-rename'       => 'שנה שם',
     'menu-delete'       => 'מחק',

--- a/resources/lang/hu/lfm.php
+++ b/resources/lang/hu/lfm.php
@@ -7,8 +7,12 @@ return [
     'nav-thumbnails'    => 'Miniatűrök',
     'nav-list'          => 'Lista',
     'nav-sort'          => 'Rendezés',
-    'nav-sort-alphabetic'=> 'ABC szerint',
+    'nav-sort-alphabetic'=> 'Név szerint',
     'nav-sort-time'     => 'Idő szerint',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Régebbi elöl',
+    'nav-sort-newest-first' => 'Újabb elöl',
 
     'menu-rename'       => 'Átnevezés',
     'menu-delete'       => 'Törlés',

--- a/resources/lang/id/lfm.php
+++ b/resources/lang/id/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Urutkan',
     'nav-sort-alphabetic'=> 'Urutkan Abjad',
     'nav-sort-time'     => 'Urutkan Waktu',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Terlama dulu',
+    'nav-sort-newest-first' => 'Terbaru dulu',
 
     'menu-rename'       => 'Ganti Nama',
     'menu-delete'       => 'Hapus',

--- a/resources/lang/it/lfm.php
+++ b/resources/lang/it/lfm.php
@@ -10,6 +10,10 @@ return [
     'nav-sort'          => 'Ordinare',
     'nav-sort-alphabetic'=> 'Ordine Alfabetico',
     'nav-sort-time'     => 'Ordine Temporale',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Prima i più vecchi',
+    'nav-sort-newest-first' => 'Prima i più recenti',
 
     'menu-rename'       => 'Rinomina',
     'menu-delete'       => 'Elimina',

--- a/resources/lang/ja/lfm.php
+++ b/resources/lang/ja/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'ソート',
     'nav-sort-alphabetic'=> 'ファイル名順',
     'nav-sort-time'     => '日付順',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => '古い順',
+    'nav-sort-newest-first' => '新しい順',
 
     'menu-rename'       => 'ファイル名変更',
     'menu-delete'       => '削除',

--- a/resources/lang/ka/lfm.php
+++ b/resources/lang/ka/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort' => 'სორტირება',
     'nav-sort-alphabetic' => 'სორტირება ანბანის მიხედვით',
     'nav-sort-time' => 'სორტირება დროის მიხედვით',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'ჯერ ძველი',
+    'nav-sort-newest-first' => 'ჯერ ახალი',
 
     'menu-rename' => 'სახელის შეცვლა',
     'menu-delete' => 'წაშლა',

--- a/resources/lang/nl/lfm.php
+++ b/resources/lang/nl/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'            => 'Sorteren',
     'nav-sort-alphabetic' => 'Sorteer op naam',
     'nav-sort-time'       => 'Sorteer op tijd',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Oudste eerst',
+    'nav-sort-newest-first' => 'Nieuwste eerst',
 
     'menu-rename'         => 'Hernoemen',
     'menu-delete'         => 'Verwijderen',

--- a/resources/lang/pl/lfm.php
+++ b/resources/lang/pl/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sortuj',
     'nav-sort-alphabetic'=> 'Sortuj alfabetycznie',
     'nav-sort-time'     => 'Sortuj według czasu',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Najstarsze najpierw',
+    'nav-sort-newest-first' => 'Najnowsze najpierw',
 
     'menu-rename'       => 'Zmień nazwę',
     'menu-delete'       => 'Usuń',

--- a/resources/lang/pt-BR/lfm.php
+++ b/resources/lang/pt-BR/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Ordenar',
     'nav-sort-alphabetic'=> 'Ordenar alfabeticamente',
     'nav-sort-time'     => 'Ordenar por data',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Mais antigos primeiro',
+    'nav-sort-newest-first' => 'Mais recentes primeiro',
 
     'menu-rename'       => 'Renomear',
     'menu-delete'       => 'Deletar',

--- a/resources/lang/pt/lfm.php
+++ b/resources/lang/pt/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Ordenar',
     'nav-sort-alphabetic'=> 'Ordenar alfabeticamente',
     'nav-sort-time'     => 'Ordenar por data',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Mais antigos primeiro',
+    'nav-sort-newest-first' => 'Mais recentes primeiro',
 
     'menu-rename'       => 'Renomear',
     'menu-delete'       => 'Apagar',

--- a/resources/lang/ro/lfm.php
+++ b/resources/lang/ro/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sortează',
     'nav-sort-alphabetic'=> 'După Alfabet',
     'nav-sort-time'     => 'După timp',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Cele mai vechi primele',
+    'nav-sort-newest-first' => 'Cele mai noi primele',
 
     'menu-rename'       => 'Redenumește',
     'menu-delete'       => 'Șterge',

--- a/resources/lang/rs/lfm.php
+++ b/resources/lang/rs/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort' => 'Poredaj',
     'nav-sort-alphabetic' => 'Poredaj po abecedi',
     'nav-sort-time' => 'Poredaj po vremenu',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Najstarije prvo',
+    'nav-sort-newest-first' => 'Najnovije prvo',
 
     'menu-rename' => 'Preimenuj',
     'menu-delete' => 'Izbriši',

--- a/resources/lang/ru/lfm.php
+++ b/resources/lang/ru/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Сортировать',
     'nav-sort-alphabetic'=> 'Сортировать по алфавиту',
     'nav-sort-time'     => 'Сортировать по времени',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Сначала старые',
+    'nav-sort-newest-first' => 'Сначала новые',
 
     'menu-rename'       => 'Переименовать',
     'menu-delete'       => 'Удалить',

--- a/resources/lang/sk/lfm.php
+++ b/resources/lang/sk/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Zoradiť',
     'nav-sort-alphabetic'=> 'Zoradiť podľa abecedy',
     'nav-sort-time'     => 'Zoradiť podľa času',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Najstaršie najskôr',
+    'nav-sort-newest-first' => 'Najnovšie najskôr',
 
     'menu-rename'       => 'Premenovať',
     'menu-delete'       => 'Zmazať',

--- a/resources/lang/sv/lfm.php
+++ b/resources/lang/sv/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sortera',
     'nav-sort-alphabetic'=> 'Sortera efter alfabetet',
     'nav-sort-time'     => 'Sortera efter tid',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Äldsta först',
+    'nav-sort-newest-first' => 'Nyaste först',
 
     'menu-rename'       => 'Byt namn',
     'menu-delete'       => 'Ta bort',

--- a/resources/lang/tr/lfm.php
+++ b/resources/lang/tr/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sırala',
     'nav-sort-alphabetic'=> 'A-Z Sırala',
     'nav-sort-time'     => 'Zamana Göre Sırala',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Önce en eski',
+    'nav-sort-newest-first' => 'Önce en yeni',
 
     'menu-rename'       => 'Ad değiştir',
     'menu-delete'       => 'Sil',

--- a/resources/lang/uk/lfm.php
+++ b/resources/lang/uk/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Сортувати',
     'nav-sort-alphabetic'=> 'Сортувати за алфавітом',
     'nav-sort-time'     => 'Сортувати за часом',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Спочатку старі',
+    'nav-sort-newest-first' => 'Спочатку нові',
 
     'menu-rename'       => 'Перейменувати',
     'menu-delete'       => 'Вилучити',

--- a/resources/lang/uz/lfm.php
+++ b/resources/lang/uz/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'            => 'Saralash',
     'nav-sort-alphabetic' => 'Alifbo tartibida saralash',
     'nav-sort-time'       => 'Vaqt bo`yicha saralash',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Avval eskilari',
+    'nav-sort-newest-first' => 'Avval yangilari',
 
     'menu-rename'   => 'Qayta nomlash',
     'menu-delete'   => "O'chirish",

--- a/resources/lang/vi/lfm.php
+++ b/resources/lang/vi/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => 'Sắp xếp',
     'nav-sort-alphabetic'=> 'Sắp xếp theo bảng chữ cái',
     'nav-sort-time'     => 'Sắp xếp theo thời gian',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => 'Cũ nhất trước',
+    'nav-sort-newest-first' => 'Mới nhất trước',
 
     'menu-rename'       => 'Đổi tên',
     'menu-delete'       => 'Xóa bỏ',

--- a/resources/lang/zh-CN/lfm.php
+++ b/resources/lang/zh-CN/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => '排序',
     'nav-sort-alphabetic'=> '按字母排序',
     'nav-sort-time'     => '按时间排序',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => '最旧优先',
+    'nav-sort-newest-first' => '最新优先',
 
     'menu-rename'       => '重命名',
     'menu-delete'       => '删除',

--- a/resources/lang/zh-TW/lfm.php
+++ b/resources/lang/zh-TW/lfm.php
@@ -9,6 +9,10 @@ return [
     'nav-sort'          => '排序',
     'nav-sort-alphabetic'=> '依字母排序',
     'nav-sort-time'     => '依時間排序',
+    'nav-sort-z-to-a'     => 'Z-A',
+    'nav-sort-a-to-z'     => 'A-Z',
+    'nav-sort-oldest-first' => '最舊優先',
+    'nav-sort-newest-first' => '最新優先',
 
     'menu-rename'       => '重新命名',
     'menu-delete'       => '刪除',

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -274,13 +274,23 @@
     var sortings = [
       {
         by: 'alphabetic',
+        icon: 'sort-alpha-up',
+        label: `${lang['nav-sort-alphabetic']} (${lang['nav-sort-a-to-z']})`
+      },
+      {
+        by: 'alphabetic_desc',
         icon: 'sort-alpha-down',
-        label: lang['nav-sort-alphabetic']
+        label: `${lang['nav-sort-alphabetic']} (${lang['nav-sort-z-to-a']})`
       },
       {
         by: 'time',
+        icon: 'sort-numeric-up',
+        label: `${lang['nav-sort-time']} (${lang['nav-sort-oldest-first']})`
+      },
+      {
+        by: 'time_desc',
         icon: 'sort-numeric-down',
-        label: lang['nav-sort-time']
+        label: `${lang['nav-sort-time']} (${lang['nav-sort-newest-first']})`
       }
     ];
   </script>

--- a/src/LfmPath.php
+++ b/src/LfmPath.php
@@ -206,14 +206,29 @@ class LfmPath
     public function sortByColumn($arr_items)
     {
         $sort_by = $this->helper->input('sort_type');
-        if (in_array($sort_by, ['name', 'time'])) {
-            $key_to_sort = $sort_by;
-        } else {
-            $key_to_sort = 'name';
+
+        $descending = false;
+        switch ($sort_by) {
+            case 'time':
+                $key_to_sort = 'time';
+                break;
+            case 'time_desc':
+                $key_to_sort = 'time';
+                $descending = true;
+                break;
+            case 'alphabetic_desc':
+                $key_to_sort = 'name';
+                $descending = true;
+                break;
+            default:
+                $key_to_sort = 'name';
+                break;
         }
 
-        uasort($arr_items, function ($a, $b) use ($key_to_sort) {
-            return strcasecmp($a->{$key_to_sort}, $b->{$key_to_sort});
+        uasort($arr_items, function ($a, $b) use ($key_to_sort, $descending) {
+            $result = strcasecmp($a->{$key_to_sort}, $b->{$key_to_sort});
+
+            return $descending ? -$result : $result;
         });
 
         if (config('lfm.is_reverse_view', false)) {


### PR DESCRIPTION
#### Summary of the change: Add ascending/descending sort options for name and time.

Previously the file manager only supported sorting items in a single (ascending) direction for name and time. This change introduces explicit ascending and descending variants for both sort criteria, giving users full control over the ordering.

Changes:
- LfmPath::sortByColumn() now recognizes the new 'alphabetic_desc' and 'time_desc' sort types and reverses the comparison result when a descending order is requested.
- The sort dropdown in index.blade.php now exposes four options (name A–Z, name Z–A, time oldest-first, time newest-first), each with its own icon and a descriptive label.
- Added the corresponding 'nav-sort-a-to-z', 'nav-sort-z-to-a', 'nav-sort-oldest-first' and 'nav-sort-newest-first' translation keys across all supported locales.